### PR TITLE
prevent skilllevel from going above 5

### DIFF
--- a/src/EVEMon.Common/Models/Skill.cs
+++ b/src/EVEMon.Common/Models/Skill.cs
@@ -75,6 +75,7 @@ namespace EVEMon.Common.Models
             SkillPoints = src.Skillpoints;
             LastConfirmedLvl = src.Level;
             m_level = src.Level;
+            m_level = Math.Min(m_level, 5);
         }
 
         /// <summary>
@@ -100,6 +101,7 @@ namespace EVEMon.Common.Models
         {
             m_known = true;
             m_level++;
+            m_level = Math.Min(m_level, 5);
             SkillPoints = StaticData.GetPointsRequiredForLevel(Math.Min(m_level, 5));
         }
 


### PR DESCRIPTION
I had the problem that for some reason MarkeAsCompleted was called too often and a skill went over level 5 which makes EveMon stop working. This code prevents this from ever happening. (on MarkeAsCompleted and Import)