### PR TITLE
Bugfixes/industryjobs

### DIFF
--- a/src/EVEMon.Common/Enumerations/CCPAPI/CCPJobCompletedStatus.cs
+++ b/src/EVEMon.Common/Enumerations/CCPAPI/CCPJobCompletedStatus.cs
@@ -2,12 +2,12 @@
 {
     public enum CCPJobCompletedStatus
     {
-        Installed = 1,
+        Active = 1,
         Paused = 2,
         Ready = 3,
 
         Delivered = 101,
-        Canceled = 102,
+        Cancelled = 102,
         Reverted = 103,
     }
 }

--- a/src/EVEMon.Common/Models/Comparers/IndustryJobComparer.cs
+++ b/src/EVEMon.Common/Models/Comparers/IndustryJobComparer.cs
@@ -97,9 +97,25 @@ namespace EVEMon.Common.Models.Comparers
                 case IndustryJobColumn.Location:
                     return String.Compare(x.FullLocation, y.FullLocation, StringComparison.CurrentCulture);
                 case IndustryJobColumn.Region:
-                    return x.SolarSystem.Constellation.Region.CompareTo(y.SolarSystem.Constellation.Region);
+                    if (x.SolarSystem != null && y.SolarSystem != null)
+                        return x.SolarSystem.Constellation.Region.CompareTo(y.SolarSystem.Constellation.Region);
+                    if (x.SolarSystem == null)
+                    {
+                        if (y.SolarSystem == null)
+                            return 0;
+                        return -1;
+                    }
+                    return 1;
                 case IndustryJobColumn.SolarSystem:
-                    return x.SolarSystem.CompareTo(y.SolarSystem);
+                    if (x.SolarSystem != null && y.SolarSystem != null)
+                        return x.SolarSystem.CompareTo(y.SolarSystem);
+                    if (x.SolarSystem == null)
+                    {
+                        if (y.SolarSystem == null)
+                            return 0;
+                        return -1;
+                    }
+                    return 1;
                 case IndustryJobColumn.Installation:
                     return String.Compare(x.Installation, y.Installation, StringComparison.CurrentCulture);
                 case IndustryJobColumn.IssuedFor:

--- a/src/EVEMon.Common/Models/IndustryJob.cs
+++ b/src/EVEMon.Common/Models/IndustryJob.cs
@@ -197,7 +197,7 @@ namespace EVEMon.Common.Models
         /// <summary>
         /// Gets the job installation full celestrial path.
         /// </summary>
-        public string FullLocation => $"{SolarSystem.FullLocation} > {Installation}";
+        public string FullLocation => $"{SolarSystem?.FullLocation ?? "Unknown"} > {Installation}";
 
         /// <summary>
         /// Gets for which the job was issued.

--- a/src/EVEMon.Common/Models/IndustryJob.cs
+++ b/src/EVEMon.Common/Models/IndustryJob.cs
@@ -385,10 +385,10 @@ namespace EVEMon.Common.Models
             switch ((CCPJobCompletedStatus)src.Status)
             {
                 // Active States
-                case CCPJobCompletedStatus.Installed:
+                case CCPJobCompletedStatus.Active:
                     return JobState.Active;
                 // Canceled States
-                case CCPJobCompletedStatus.Canceled:
+                case CCPJobCompletedStatus.Cancelled:
                     return JobState.Canceled;
                 // Failed States
                 case CCPJobCompletedStatus.Reverted:

--- a/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.cs
@@ -373,7 +373,7 @@ namespace EVEMon.CharacterMonitoring
             try
             {
                 IEnumerable<IndustryJob> jobs = m_list
-                    .Where(x => x.InstalledItem != null && x.OutputItem != null && x.SolarSystem != null)
+                    .Where(x => x.InstalledItem != null && x.OutputItem != null)
                     .Where(x => IsTextMatching(x, m_textFilter));
 
                 if (Character != null && Settings.UI.MainWindow.IndustryJobs.HideInactiveJobs)

--- a/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.cs
@@ -573,7 +573,7 @@ namespace EVEMon.CharacterMonitoring
                 .AppendLine()
                 .Append($"Activity: {job.Activity.GetDescription()}")
                 .AppendLine()
-                .Append($"Solar System: {job.SolarSystem.FullLocation}")
+                .Append($"Solar System: {job.SolarSystem?.FullLocation ?? "Unknown"}")
                 .AppendLine()
                 .Append($"Installation: {job.Installation}")
                 .AppendLine();

--- a/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.cs
@@ -85,6 +85,7 @@ namespace EVEMon.CharacterMonitoring
             lvJobs.MouseDown += listView_MouseDown;
             lvJobs.MouseMove += listView_MouseMove;
             lvJobs.MouseLeave += listView_MouseLeave;
+            m_init = true;
         }
 
         #endregion

--- a/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.cs
@@ -718,11 +718,11 @@ namespace EVEMon.CharacterMonitoring
                     item.Text = job.FullLocation;
                     break;
                 case IndustryJobColumn.Region:
-                    item.Text = job.SolarSystem.Constellation.Region.Name;
+                    item.Text = job.SolarSystem?.Constellation.Region.Name ?? "Unknown";
                     break;
                 case IndustryJobColumn.SolarSystem:
-                    item.Text = job.SolarSystem.Name;
-                    item.ForeColor = job.SolarSystem.SecurityLevelColor;
+                    item.Text = job.SolarSystem?.Name ?? "Unknown";
+                    item.ForeColor = job.SolarSystem?.SecurityLevelColor ?? Color.Red;
                     break;
                 case IndustryJobColumn.Installation:
                     item.Text = job.Installation;
@@ -829,14 +829,17 @@ namespace EVEMon.CharacterMonitoring
                                                                           x.Installation.ToUpperInvariant()
                                                                               .Contains(text, ignoreCase: true)
                                                                           ||
-                                                                          x.SolarSystem.Name.ToUpperInvariant()
+                                                                          (x.SolarSystem?.Name ?? "Unknown")
+                                                                              .ToUpperInvariant()
                                                                               .Contains(text, ignoreCase: true)
                                                                           ||
-                                                                          x.SolarSystem.Constellation.Name.ToUpperInvariant()
+                                                                          (x.SolarSystem?.Constellation.Name ?? "Unknown")
+                                                                              .ToUpperInvariant()
                                                                               .Contains(text, ignoreCase: true)
                                                                           ||
-                                                                          x.SolarSystem.Constellation.Region.Name.ToUpperInvariant
-                                                                              ().Contains(text, ignoreCase: true);
+                                                                          (x.SolarSystem?.Constellation.Region.Name ?? "Unknown")
+                                                                              .ToUpperInvariant()
+                                                                              .Contains(text, ignoreCase: true);
 
         /// <summary>
         /// Updates the time to completion.

--- a/src/EVEMon/Controls/NotificationList.cs
+++ b/src/EVEMon/Controls/NotificationList.cs
@@ -694,7 +694,7 @@ namespace EVEMon.Controls
             {
                 builder.Append(job.InstalledItem.Name)
                     .Append(" at ")
-                    .Append($"{job.SolarSystem.Name} > {job.Installation}")
+                    .Append($"{job.SolarSystem?.Name ?? "Unknown"} > {job.Installation}")
                     .AppendLine();
             }
             return builder.ToString();


### PR DESCRIPTION
Fixes for handling industry jobs, since they don't necessarily provide a known SolarSystem anymore.

(Through currently we are not even trying to read it from the api, but industry in citadels does not provide it anyway)

Also set m_init in CharacterIndustryJobsList.cs to true after initialization, so the JobsList actually displays something.