### PR TITLE
Add (some) support for custom scopes and reduce number of skill completed notifications

### DIFF
--- a/src/EVEMon.Common/Attributes/ParentAttribute.cs
+++ b/src/EVEMon.Common/Attributes/ParentAttribute.cs
@@ -8,7 +8,7 @@ namespace EVEMon.Common.Attributes
     {
         public ParentAttribute(params object[] parents)
         {
-            Parents = parents.Where(x => x as Enum != null).Select(x => (Enum)x).ToArray();
+            Parents = parents?.Where(x => x as Enum != null).Select(x => (Enum)x).ToArray();
         }
 
         public Enum[] Parents { get; }

--- a/src/EVEMon.Common/Attributes/ParentAttribute.cs
+++ b/src/EVEMon.Common/Attributes/ParentAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace EVEMon.Common.Attributes
+{
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+    public sealed class ParentAttribute : Attribute
+    {
+        public ParentAttribute(object parent)
+        {
+            Parent = parent as Enum;
+        }
+
+        public Enum Parent { get; }
+    }
+}

--- a/src/EVEMon.Common/Attributes/ParentAttribute.cs
+++ b/src/EVEMon.Common/Attributes/ParentAttribute.cs
@@ -1,15 +1,16 @@
 ﻿using System;
+using System.Linq;
 
 namespace EVEMon.Common.Attributes
 {
     [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
     public sealed class ParentAttribute : Attribute
     {
-        public ParentAttribute(object parent)
+        public ParentAttribute(params object[] parents)
         {
-            Parent = parent as Enum;
+            Parents = parents.Where(x => x as Enum != null).Select(x => (Enum)x).ToArray();
         }
 
-        public Enum Parent { get; }
+        public Enum[] Parents { get; }
     }
 }

--- a/src/EVEMon.Common/EVEMon.Common.csproj
+++ b/src/EVEMon.Common/EVEMon.Common.csproj
@@ -159,6 +159,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AsyncPump.cs" />
+    <Compile Include="Attributes\ParentAttribute.cs" />
     <Compile Include="CloudStorageServices\AuthenticationSteps.cs" />
     <Compile Include="Collections\Global\GlobalAPIProviderCollection.cs" />
     <Compile Include="Constants\NetworkConstants1.Designer.cs">

--- a/src/EVEMon.Common/Enumerations/CCPAPI/ESIAPICharacterMethods.cs
+++ b/src/EVEMon.Common/Enumerations/CCPAPI/ESIAPICharacterMethods.cs
@@ -18,6 +18,7 @@ namespace EVEMon.Common.Enumerations.CCPAPI
         /// <summary>
         /// A character's wallet balance.
         /// </summary>
+        [Parent(CharacterSheet)]
         AccountBalance = 1 << 0,
 
         /// <summary>
@@ -31,6 +32,7 @@ namespace EVEMon.Common.Enumerations.CCPAPI
         /// <summary>
         /// The attributes of a character.
         /// </summary>
+        [Parent(CharacterSheet)]
         Attributes = 1 << 2,
 
         /// <summary>
@@ -52,6 +54,7 @@ namespace EVEMon.Common.Enumerations.CCPAPI
         /// <summary>
         /// The clones of a character.
         /// </summary>
+        [Parent(CharacterSheet)]
         Clones = 1 << 5,
 
         /// <summary>
@@ -88,6 +91,7 @@ namespace EVEMon.Common.Enumerations.CCPAPI
         /// <summary>
         /// The employment history of a character.
         /// </summary>
+        [Parent(CharacterSheet)]
         EmploymentHistory = 1 << 11,
 
         /// <summary>
@@ -101,6 +105,7 @@ namespace EVEMon.Common.Enumerations.CCPAPI
         /// <summary>
         /// The active implants of a character.
         /// </summary>
+        [Parent(CharacterSheet)]
         Implants = 1 << 13,
 
         /// <summary>
@@ -127,6 +132,7 @@ namespace EVEMon.Common.Enumerations.CCPAPI
         /// <summary>
         /// Allows the fetching of coordinate and name data for items owned by the character.
         /// </summary>
+        [Parent(CharacterSheet)]
         Location = 1 << 17,
 
         /// <summary>
@@ -195,6 +201,7 @@ namespace EVEMon.Common.Enumerations.CCPAPI
         /// <summary>
         /// The current ship of a character.
         /// </summary>
+        [Parent(CharacterSheet)]
         Ship = 1 << 27,
 
         /// <summary>
@@ -208,6 +215,7 @@ namespace EVEMon.Common.Enumerations.CCPAPI
         /// <summary>
         /// The skills of a character.
         /// </summary>
+        [Parent(CharacterSheet)]
         Skills = 1 << 29,
 
         /// <summary>

--- a/src/EVEMon.Common/Enumerations/CCPAPI/ESIAPICharacterMethods.cs
+++ b/src/EVEMon.Common/Enumerations/CCPAPI/ESIAPICharacterMethods.cs
@@ -216,7 +216,7 @@ namespace EVEMon.Common.Enumerations.CCPAPI
         /// <summary>
         /// The skills of a character.
         /// </summary>
-        [Parent(CharacterSheet, SkillQueue)]
+        [Parent(CharacterSheet)]
         Skills = 1 << 29,
 
         /// <summary>

--- a/src/EVEMon.Common/Enumerations/CCPAPI/ESIAPICharacterMethods.cs
+++ b/src/EVEMon.Common/Enumerations/CCPAPI/ESIAPICharacterMethods.cs
@@ -151,6 +151,7 @@ namespace EVEMon.Common.Enumerations.CCPAPI
         /// <summary>
         /// The character mailing lists. Used to convert mailing list IDs to Names.
         /// </summary>
+        [Parent(MailMessages)]
         MailingLists = 1 << 20,
 
         /// <summary>
@@ -215,7 +216,7 @@ namespace EVEMon.Common.Enumerations.CCPAPI
         /// <summary>
         /// The skills of a character.
         /// </summary>
-        [Parent(CharacterSheet)]
+        [Parent(CharacterSheet, SkillQueue)]
         Skills = 1 << 29,
 
         /// <summary>

--- a/src/EVEMon.Common/Extensions/EnumExtensions.cs
+++ b/src/EVEMon.Common/Extensions/EnumExtensions.cs
@@ -37,9 +37,12 @@ namespace EVEMon.Common.Extensions
         /// <returns></returns>
         public static string GetHeader(this Enum item) => GetAttribute<HeaderAttribute>(item).Header;
 
-        public static bool HasParent(this Enum item) => GetAttribute<ParentAttribute>(item) != null;
-
-        public static Enum GetParent(this Enum item) => GetAttribute<ParentAttribute>(item).Parent;
+        /// <summary>
+        /// Gets the parents bound to the given enumeration member.
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        public static Enum[] GetParents(this Enum item) => GetAttribute<ParentAttribute>(item)?.Parents;
 
         /// <summary>
         /// Gets the period bound to the given enumeration member.

--- a/src/EVEMon.Common/Extensions/EnumExtensions.cs
+++ b/src/EVEMon.Common/Extensions/EnumExtensions.cs
@@ -38,11 +38,11 @@ namespace EVEMon.Common.Extensions
         public static string GetHeader(this Enum item) => GetAttribute<HeaderAttribute>(item).Header;
 
         /// <summary>
-        /// Gets the parents bound to the given enumeration member.
+        /// Checks whether the given member has a specific parent.
         /// </summary>
         /// <param name="item"></param>
         /// <returns></returns>
-        public static Enum[] GetParents(this Enum item) => GetAttribute<ParentAttribute>(item)?.Parents;
+        public static bool HasParent(this Enum item, Enum other) => GetAttribute<ParentAttribute>(item)?.Parents?.Any(e => other.Equals(e)) ?? false;
 
         /// <summary>
         /// Gets the period bound to the given enumeration member.

--- a/src/EVEMon.Common/Extensions/EnumExtensions.cs
+++ b/src/EVEMon.Common/Extensions/EnumExtensions.cs
@@ -37,6 +37,10 @@ namespace EVEMon.Common.Extensions
         /// <returns></returns>
         public static string GetHeader(this Enum item) => GetAttribute<HeaderAttribute>(item).Header;
 
+        public static bool HasParent(this Enum item) => GetAttribute<ParentAttribute>(item) != null;
+
+        public static Enum GetParent(this Enum item) => GetAttribute<ParentAttribute>(item).Parent;
+
         /// <summary>
         /// Gets the period bound to the given enumeration member.
         /// </summary>

--- a/src/EVEMon.Common/Models/Character.cs
+++ b/src/EVEMon.Common/Models/Character.cs
@@ -788,14 +788,48 @@ namespace EVEMon.Common.Models
         /// Imports data from the given skills information.
         /// </summary>
         /// <param name="skills">The serialized character skill information</param>
-        internal void Import(EsiAPISkills skills)
+        internal void Import(EsiAPISkills skills, EsiAPISkillQueue queue)
         {
             var newSkills = new LinkedList<SerializableCharacterSkill>();
 
             FreeSkillPoints = skills.UnallocatedSP;
+
+            // Keep track of the current skill queue's completed skills, as ESI doesn't transfer them to the skills list until you login
+            Dictionary<long, QueuedSkill> dict = new Dictionary<long, QueuedSkill>();
+            if (queue != null && IsTraining)
+            {
+                DateTime uselessDate = DateTime.UtcNow;
+
+                foreach (var serialSkill in queue.ToXMLItem().Queue)
+                {
+                    var queuedSkill = new QueuedSkill(this, serialSkill, ref uselessDate);
+                    if (!dict.ContainsKey(queuedSkill.Skill.ID))
+                        dict.Add(queuedSkill.Skill.ID, queuedSkill);
+                    else if (queuedSkill.Level > dict[queuedSkill.Skill.ID].Level)
+                        dict[queuedSkill.Skill.ID] = queuedSkill;
+                }
+            }
             // Convert skills to EVE format
             foreach (var skill in skills.Skills)
+            {
+                // Check if the skill is in the queue, and completed at a higher level or has higher current SP
+                if (dict.ContainsKey(skill.ID))
+                {
+                    var queuedSkill = dict[skill.ID];
+
+                    if (queuedSkill.IsCompleted)
+                    {
+                        skill.ActiveLevel = Math.Max(skill.ActiveLevel, queuedSkill.Level);
+                        skill.Level = Math.Max(skill.Level, queuedSkill.Level);
+                        skill.Skillpoints = Math.Max(skill.Skillpoints, queuedSkill.EndSP);
+                    }
+                    else
+                        skill.Skillpoints = Math.Max(skill.Skillpoints, queuedSkill.CurrentSP);
+                }
+
                 newSkills.AddLast(skill.ToXMLItem());
+            }
+
             Skills.Import(newSkills, true);
         }
 

--- a/src/EVEMon.Common/Models/QueuedSkill.cs
+++ b/src/EVEMon.Common/Models/QueuedSkill.cs
@@ -16,7 +16,6 @@ namespace EVEMon.Common.Models
         /// </summary>
         /// <param name="character">The character for this training</param>
         /// <param name="serial">The serialization object for this training</param>
-        /// <param name="isPaused">When true, the training is currently paused.</param>
         /// <param name="startTimeWhenPaused">Training starttime when the queue is actually paused.
         /// Indeed, in such case, CCP returns empty start and end time, so we compute a "what if we start now" scenario.</param>
         internal QueuedSkill(Character character, SerializableQueuedSkill serial,
@@ -28,7 +27,7 @@ namespace EVEMon.Common.Models
             Level = serial.Level;
             Skill = character.Skills[serial.ID];
 
-            if (!serial.IsPaused)
+            if (serial.IsTraining)
             {
                 // Not paused, we should trust CCP
                 StartTime = serial.StartTime;

--- a/src/EVEMon.Common/Models/QueuedSkill.cs
+++ b/src/EVEMon.Common/Models/QueuedSkill.cs
@@ -20,7 +20,7 @@ namespace EVEMon.Common.Models
         /// <param name="startTimeWhenPaused">Training starttime when the queue is actually paused.
         /// Indeed, in such case, CCP returns empty start and end time, so we compute a "what if we start now" scenario.</param>
         internal QueuedSkill(Character character, SerializableQueuedSkill serial,
-            bool isPaused, ref DateTime startTimeWhenPaused)
+            ref DateTime startTimeWhenPaused)
         {
             Owner = character;
             StartSP = serial.StartSP;
@@ -28,7 +28,9 @@ namespace EVEMon.Common.Models
             Level = serial.Level;
             Skill = character.Skills[serial.ID];
 
-            if (!isPaused)
+            // When the skill queue is paused, startTime and endTime are empty in the XML document
+            // As a result, the serialization leaves the DateTime with its default value
+            if (serial.EndTime != DateTime.MinValue)
             {
                 // Not paused, we should trust CCP
                 StartTime = serial.StartTime;

--- a/src/EVEMon.Common/Models/QueuedSkill.cs
+++ b/src/EVEMon.Common/Models/QueuedSkill.cs
@@ -28,9 +28,7 @@ namespace EVEMon.Common.Models
             Level = serial.Level;
             Skill = character.Skills[serial.ID];
 
-            // When the skill queue is paused, startTime and endTime are empty in the XML document
-            // As a result, the serialization leaves the DateTime with its default value
-            if (serial.EndTime != DateTime.MinValue)
+            if (!serial.IsPaused)
             {
                 // Not paused, we should trust CCP
                 StartTime = serial.StartTime;

--- a/src/EVEMon.Common/Models/Skill.cs
+++ b/src/EVEMon.Common/Models/Skill.cs
@@ -96,6 +96,16 @@ namespace EVEMon.Common.Models
         }
 
         /// <summary>
+        /// Check if the input level is higher than the current level
+        /// </summary>
+        /// <param name="newLevel"></param>
+        /// <returns></returns>
+        internal bool HasBeenCompleted(long newLevel)
+        {
+            return Math.Min(newLevel, s_maxLevel) > m_level;
+        }
+
+        /// <summary>
         /// Marks the skill as completed
         /// </summary>
         internal void MarkAsCompleted()

--- a/src/EVEMon.Common/Models/Skill.cs
+++ b/src/EVEMon.Common/Models/Skill.cs
@@ -100,19 +100,27 @@ namespace EVEMon.Common.Models
         /// </summary>
         /// <param name="newLevel"></param>
         /// <returns></returns>
-        internal bool HasBeenCompleted(long newLevel)
+        internal bool HasBeenCompleted(QueuedSkill queuedSkill)
         {
-            return Math.Min(newLevel, s_maxLevel) > m_level;
+            return Math.Min(queuedSkill.Level, s_maxLevel) > m_level;
         }
 
         /// <summary>
-        /// Marks the skill as completed
+        /// Updates the skill to match the one from the queue
         /// </summary>
-        internal void MarkAsCompleted()
+        internal void UpdateSkillProgress(QueuedSkill queuedSkill)
         {
             m_known = true;
-            m_level = Math.Min(m_level + 1, s_maxLevel);
-            SkillPoints = StaticData.GetPointsRequiredForLevel(m_level);
+            if (queuedSkill.IsCompleted)
+            {
+                m_level = Math.Min(queuedSkill.Level, s_maxLevel);
+                SkillPoints = queuedSkill.EndSP;
+            }
+            else
+            {
+                m_level = queuedSkill.Level - 1;
+                SkillPoints = queuedSkill.CurrentSP;
+            }
         }
 
         /// <summary>

--- a/src/EVEMon.Common/Models/SkillQueue.cs
+++ b/src/EVEMon.Common/Models/SkillQueue.cs
@@ -182,7 +182,7 @@ namespace EVEMon.Common.Models
             Items.Clear();
             foreach (SerializableQueuedSkill serialSkill in serial)
             {
-                if (serialSkill.IsPaused)
+                if (!serialSkill.IsTraining)
                     IsPaused = true;
 
                 // Creates the skill queue

--- a/src/EVEMon.Common/Models/SkillQueue.cs
+++ b/src/EVEMon.Common/Models/SkillQueue.cs
@@ -106,10 +106,10 @@ namespace EVEMon.Common.Models
             while (Items.Count > 0 && (skill = Items[0]).EndTime <= now)
             {
                 var skillTrained = skill.Skill;
-                if (skillTrained != null)
+                if (skillTrained != null && skillTrained.HasBeenCompleted(skill.Level))
                 {
                     // The skill has been completed
-                    skill.Skill?.MarkAsCompleted();
+                    skillTrained.MarkAsCompleted();
                     skillsCompleted.AddLast(skill);
                     LastCompleted = skill;
                     // Send an email alert if configured
@@ -171,13 +171,8 @@ namespace EVEMon.Common.Models
             Items.Clear();
             foreach (SerializableQueuedSkill serialSkill in serial)
             {
-                // When the skill queue is paused, startTime and endTime are empty in the XML document
-                // As a result, the serialization leaves the DateTime with its default value
-                if (serialSkill.EndTime == DateTime.MinValue)
-                    IsPaused = true;
-
                 // Creates the skill queue
-                Items.Add(new QueuedSkill(m_character, serialSkill, IsPaused, ref startTimeWhenPaused));
+                Items.Add(new QueuedSkill(m_character, serialSkill, ref startTimeWhenPaused));
             }
 
             // Fires the event regarding the character skill queue update

--- a/src/EVEMon.Common/Models/SkillQueue.cs
+++ b/src/EVEMon.Common/Models/SkillQueue.cs
@@ -171,6 +171,9 @@ namespace EVEMon.Common.Models
             Items.Clear();
             foreach (SerializableQueuedSkill serialSkill in serial)
             {
+                if (serialSkill.IsPaused)
+                    IsPaused = true;
+
                 // Creates the skill queue
                 Items.Add(new QueuedSkill(m_character, serialSkill, ref startTimeWhenPaused));
             }

--- a/src/EVEMon.Common/Models/SkillQueue.cs
+++ b/src/EVEMon.Common/Models/SkillQueue.cs
@@ -99,7 +99,6 @@ namespace EVEMon.Common.Models
         private void UpdateOnTimerTick()
         {
             var skillsCompleted = new LinkedList<QueuedSkill>();
-            bool skillQueueUpdated = false;
             QueuedSkill skill;
             Skill skillTrained;
 
@@ -128,12 +127,7 @@ namespace EVEMon.Common.Models
                         Emailer.SendSkillCompletionMail(Items, skill, m_character);
                 }
                 Items.RemoveAt(0);
-
-                skillQueueUpdated = true;
             }
-
-            if (skillQueueUpdated)
-                EveMonClient.OnCharacterSkillQueueUpdated(m_character);
 
             if (skillsCompleted.Any() && !Settings.IsRestoring)
             {
@@ -194,6 +188,9 @@ namespace EVEMon.Common.Models
                 // Creates the skill queue
                 Items.Add(new QueuedSkill(m_character, serialSkill, ref startTimeWhenPaused));
             }
+
+            // Update skills with the imported data
+            UpdateOnTimerTick();
 
             // Fires the event regarding the character skill queue update
             EveMonClient.OnCharacterSkillQueueUpdated(m_character);

--- a/src/EVEMon.Common/QueryMonitor/CharacterDataQuerying.cs
+++ b/src/EVEMon.Common/QueryMonitor/CharacterDataQuerying.cs
@@ -18,6 +18,8 @@ namespace EVEMon.Common.QueryMonitor
         #region Fields
 
         private readonly CharacterQueryMonitor<EsiAPICharacterSheet> m_charSheetMonitor;
+        private readonly CharacterQueryMonitor<EsiAPISkillQueue> m_charSkillQueueMonitor;
+        private readonly CharacterQueryMonitor<EsiAPISkills> m_charSkillsMonitor;
         private readonly CharacterQueryMonitor<EsiAPIMarketOrders> m_charMarketOrdersMonitor;
         private readonly CharacterQueryMonitor<EsiAPIContracts> m_charContractsMonitor;
         private readonly CharacterQueryMonitor<EsiAPIIndustryJobs> m_charIndustryJobsMonitor;
@@ -67,13 +69,15 @@ namespace EVEMon.Common.QueryMonitor
                 ccpCharacter, ESIAPICharacterMethods.Ship, OnCharacterShipUpdated,
                 notifiers.NotifyCharacterShipError));
             // Skills
-            m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPISkills>(
+            m_charSkillsMonitor = new CharacterQueryMonitor<EsiAPISkills>(
                 ccpCharacter, ESIAPICharacterMethods.Skills, OnCharacterSkillsUpdated,
-                notifiers.NotifyCharacterSkillsError));
+                notifiers.NotifyCharacterSkillsError);
+            m_characterQueryMonitors.Add(m_charSkillsMonitor);
             // Skill queue
-            m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPISkillQueue>(
+            m_charSkillQueueMonitor = new CharacterQueryMonitor<EsiAPISkillQueue>(
                 ccpCharacter, ESIAPICharacterMethods.SkillQueue, OnSkillQueueUpdated,
-                notifiers.NotifySkillQueueError));
+                notifiers.NotifySkillQueueError);
+            m_characterQueryMonitors.Add(m_charSkillQueueMonitor);
             // Employment history
             m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIEmploymentHistory>(
                 ccpCharacter, ESIAPICharacterMethods.EmploymentHistory, OnCharacterEmploymentUpdated,
@@ -367,7 +371,7 @@ namespace EVEMon.Common.QueryMonitor
             // Character may have been deleted since we queried
             if (target != null)
             {
-                target.Import(result);
+                target.Import(result, m_charSkillQueueMonitor?.LastResult?.Result);
             }
         }
 

--- a/src/EVEMon.Common/QueryMonitor/CharacterDataQuerying.cs
+++ b/src/EVEMon.Common/QueryMonitor/CharacterDataQuerying.cs
@@ -43,60 +43,109 @@ namespace EVEMon.Common.QueryMonitor
                 ESIAPICharacterMethods.CharacterSheet, OnCharacterSheetUpdated,
                 notifiers.NotifyCharacterSheetError);
             m_characterQueryMonitors.Add(m_charSheetMonitor);
+            // Location
+            m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPILocation>(
+                ccpCharacter, ESIAPICharacterMethods.Location, OnCharacterLocationUpdated,
+                notifiers.NotifyCharacterLocationError));
+            // Clones
+            m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIClones>(
+                ccpCharacter, ESIAPICharacterMethods.Clones, OnCharacterClonesUpdated,
+                notifiers.NotifyCharacterClonesError));
+            // Implants
+            m_characterQueryMonitors.Add(new CharacterQueryMonitor<List<int>>(
+                ccpCharacter, ESIAPICharacterMethods.Implants, OnCharacterImplantsUpdated,
+                notifiers.NotifyCharacterImplantsError));
+            // Attributes
+            m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIAttributes>(
+                ccpCharacter, ESIAPICharacterMethods.Attributes, OnCharacterAttributesUpdated,
+                notifiers.NotifyCharacterAttributesError));
+            // Ship
+            m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIShip>(
+                ccpCharacter, ESIAPICharacterMethods.Ship, OnCharacterShipUpdated,
+                notifiers.NotifyCharacterShipError));
+            // Skills
+            m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPISkills>(
+                ccpCharacter, ESIAPICharacterMethods.Skills, OnCharacterSkillsUpdated,
+                notifiers.NotifyCharacterSkillsError));
+            // Skill queue
             m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPISkillQueue>(
                 ccpCharacter, ESIAPICharacterMethods.SkillQueue, OnSkillQueueUpdated,
                 notifiers.NotifySkillQueueError));
+            // Employment history
+            m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIEmploymentHistory>(
+                ccpCharacter, ESIAPICharacterMethods.EmploymentHistory, OnCharacterEmploymentUpdated,
+                notifiers.NotifyCharacterEmploymentError));
+            // Standings
             m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIStandings>(
                 ccpCharacter, ESIAPICharacterMethods.Standings, OnStandingsUpdated,
                 notifiers.NotifyCharacterStandingsError) { QueryOnStartup = true });
+            // Contacts
             m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIContactsList>(
                 ccpCharacter, ESIAPICharacterMethods.ContactList, OnContactsUpdated,
                 notifiers.NotifyCharacterContactsError) { QueryOnStartup = true });
+            // Factional warfare
             m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIFactionalWarfareStats>(
                 ccpCharacter, ESIAPICharacterMethods.FactionalWarfareStats,
                 OnFactionalWarfareStatsUpdated, notifiers.
                 NotifyCharacterFactionalWarfareStatsError) { QueryOnStartup = true });
+            // Medals
             m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIMedals>(ccpCharacter,
                 ESIAPICharacterMethods.Medals, OnMedalsUpdated,
                 notifiers.NotifyCharacterMedalsError) { QueryOnStartup = true });
+            // Kill log
             m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIKillLog>(ccpCharacter,
                 ESIAPICharacterMethods.KillLog, OnKillLogUpdated,
                 notifiers.NotifyCharacterKillLogError) { QueryOnStartup = true });
+            // Assets
             m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIAssetList>(ccpCharacter,
                 ESIAPICharacterMethods.AssetList, OnAssetsUpdated,
                 notifiers.NotifyCharacterAssetsError) { QueryOnStartup = true });
+            // Market orders
             m_charMarketOrdersMonitor = new CharacterQueryMonitor<EsiAPIMarketOrders>(
                 ccpCharacter, ESIAPICharacterMethods.MarketOrders, OnMarketOrdersUpdated,
                 notifiers.NotifyCharacterMarketOrdersError) { QueryOnStartup = true };
             m_characterQueryMonitors.Add(m_charMarketOrdersMonitor);
+            // Contracts
             m_charContractsMonitor = new CharacterQueryMonitor<EsiAPIContracts>(ccpCharacter,
                 ESIAPICharacterMethods.Contracts, OnContractsUpdated,
                 notifiers.NotifyCharacterContractsError) { QueryOnStartup = true };
             m_characterQueryMonitors.Add(m_charContractsMonitor);
+            // Wallet journal
             m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIWalletJournal>(
                 ccpCharacter, ESIAPICharacterMethods.WalletJournal, OnWalletJournalUpdated,
                 notifiers.NotifyCharacterWalletJournalError) { QueryOnStartup = true });
+            // Wallet balance
+            m_characterQueryMonitors.Add(new CharacterQueryMonitor<string>(
+                ccpCharacter, ESIAPICharacterMethods.AccountBalance, OnWalletBalanceUpdated,
+                notifiers.NotifyCharacterBalanceError));
+            // Wallet transactions
             m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIWalletTransactions>(
                 ccpCharacter, ESIAPICharacterMethods.WalletTransactions,
                 OnWalletTransactionsUpdated, notifiers.NotifyCharacterWalletTransactionsError)
             { QueryOnStartup = true });
+            // Industry
             m_charIndustryJobsMonitor = new CharacterQueryMonitor<EsiAPIIndustryJobs>(
                 ccpCharacter, ESIAPICharacterMethods.IndustryJobs, OnIndustryJobsUpdated,
                 notifiers.NotifyCharacterIndustryJobsError) { QueryOnStartup = true };
             m_characterQueryMonitors.Add(m_charIndustryJobsMonitor);
+            // Research points
             m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIResearchPoints>(
                 ccpCharacter, ESIAPICharacterMethods.ResearchPoints, OnResearchPointsUpdated,
                 notifiers.NotifyCharacterResearchPointsError) { QueryOnStartup = true });
+            // Mail
             m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIMailMessages>(
                 ccpCharacter, ESIAPICharacterMethods.MailMessages, OnEVEMailMessagesUpdated,
                 notifiers.NotifyEVEMailMessagesError) { QueryOnStartup = true });
+            // Notifications
             m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPINotifications>(
                 ccpCharacter, ESIAPICharacterMethods.Notifications, OnEVENotificationsUpdated,
                 notifiers.NotifyEVENotificationsError) { QueryOnStartup = true });
+            // Calendar
             m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPICalendarEvents>(
                 ccpCharacter, ESIAPICharacterMethods.UpcomingCalendarEvents,
                 OnUpcomingCalendarEventsUpdated, notifiers.
                 NotifyCharacterUpcomingCalendarEventsError) { QueryOnStartup = true });
+            // PI
             m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIPlanetaryColoniesList>(
                 ccpCharacter, ESIAPICharacterMethods.PlanetaryColonies,
                 OnPlanetaryColoniesUpdated, notifiers.
@@ -219,10 +268,6 @@ namespace EVEMon.Common.QueryMonitor
             // Character may have been deleted since we queried
             if (target != null)
             {
-                // Query remaining character data
-                QueryCharacterData<EsiAPILocation>(ESIAPICharacterMethods.Location,
-                    EveMonClient.Notifications.NotifyCharacterLocationError,
-                    OnCharacterLocationUpdated);
                 target.Import(result);
             }
         }
@@ -238,9 +283,6 @@ namespace EVEMon.Common.QueryMonitor
             if (target != null)
             {
                 target.Import(result);
-                QueryCharacterData<EsiAPIClones>(ESIAPICharacterMethods.Clones,
-                    EveMonClient.Notifications.NotifyCharacterClonesError,
-                    OnCharacterClonesUpdated);
             }
         }
 
@@ -255,9 +297,6 @@ namespace EVEMon.Common.QueryMonitor
             if (target != null)
             {
                 target.Import(result);
-                QueryCharacterData<List<int>>(ESIAPICharacterMethods.Implants,
-                    EveMonClient.Notifications.NotifyCharacterImplantsError,
-                    OnCharacterImplantsUpdated);
             }
         }
 
@@ -272,9 +311,6 @@ namespace EVEMon.Common.QueryMonitor
             if (target != null)
             {
                 target.Import(result);
-                QueryCharacterData<EsiAPIAttributes>(ESIAPICharacterMethods.Attributes,
-                    EveMonClient.Notifications.NotifyCharacterAttributesError,
-                    OnCharacterAttributesUpdated);
             }
         }
 
@@ -289,9 +325,6 @@ namespace EVEMon.Common.QueryMonitor
             if (target != null)
             {
                 target.Import(result);
-                QueryCharacterData<EsiAPIShip>(ESIAPICharacterMethods.Ship,
-                    EveMonClient.Notifications.NotifyCharacterShipError,
-                    OnCharacterShipUpdated);
             }
         }
 
@@ -306,9 +339,6 @@ namespace EVEMon.Common.QueryMonitor
             if (target != null)
             {
                 target.Import(result);
-                QueryCharacterData<EsiAPISkills>(ESIAPICharacterMethods.Skills,
-                    EveMonClient.Notifications.NotifyCharacterSkillsError,
-                    OnCharacterSkillsUpdated);
             }
         }
 
@@ -323,9 +353,6 @@ namespace EVEMon.Common.QueryMonitor
             if (target != null)
             {
                 target.Import(result);
-                QueryCharacterData<EsiAPIEmploymentHistory>(ESIAPICharacterMethods.
-                    EmploymentHistory, EveMonClient.Notifications.
-                    NotifyCharacterEmploymentError, OnCharacterEmploymentUpdated);
             }
         }
 
@@ -340,9 +367,6 @@ namespace EVEMon.Common.QueryMonitor
             if (target != null)
             {
                 target.Import(result);
-                QueryCharacterData<string>(ESIAPICharacterMethods.AccountBalance,
-                    EveMonClient.Notifications.NotifyCharacterBalanceError,
-                    OnWalletBalanceUpdated);
             }
         }
         

--- a/src/EVEMon.Common/QueryMonitor/CharacterQueryMonitor.cs
+++ b/src/EVEMon.Common/QueryMonitor/CharacterQueryMonitor.cs
@@ -37,7 +37,7 @@ namespace EVEMon.Common.QueryMonitor
                 }
 
                 foreach(var monitor in character.QueryMonitors.Where(
-                    monitor => monitor.Method.HasParent() && method.Equals(monitor.Method.GetParent())))
+                    monitor => monitor.Method.GetParents()?.Any(m => method.Equals(m)) == true))
                 {
                     character.QueryMonitors.Query(monitor.Method);
                 }

--- a/src/EVEMon.Common/QueryMonitor/CharacterQueryMonitor.cs
+++ b/src/EVEMon.Common/QueryMonitor/CharacterQueryMonitor.cs
@@ -35,6 +35,12 @@ namespace EVEMon.Common.QueryMonitor
                     if (!result.HasError)
                         onSuccess.Invoke(result.Result);
                 }
+
+                foreach(var monitor in character.QueryMonitors.Where(
+                    monitor => monitor.Method.HasParent() && method.Equals(monitor.Method.GetParent())))
+                {
+                    character.QueryMonitors.Query(monitor.Method);
+                }
             })
         {
             m_character = character;

--- a/src/EVEMon.Common/QueryMonitor/CharacterQueryMonitor.cs
+++ b/src/EVEMon.Common/QueryMonitor/CharacterQueryMonitor.cs
@@ -37,7 +37,7 @@ namespace EVEMon.Common.QueryMonitor
                 }
 
                 foreach(var monitor in character.QueryMonitors.Where(
-                    monitor => monitor.Method.GetParents()?.Any(m => method.Equals(m)) == true))
+                    monitor => monitor.Method.HasParent(method)))
                 {
                     character.QueryMonitors.Query(monitor.Method);
                 }

--- a/src/EVEMon.Common/Serialization/Eve/SerializableQueuedSkill.cs
+++ b/src/EVEMon.Common/Serialization/Eve/SerializableQueuedSkill.cs
@@ -41,9 +41,9 @@ namespace EVEMon.Common.Serialization.Eve
         // When the skill queue is paused, startTime and endTime are empty in the XML document
         // As a result, the serialization leaves the DateTime with its default value
         [XmlIgnore]
-        public bool IsPaused
+        public bool IsTraining
         {
-            get { return EndTime == DateTime.MinValue; }
+            get { return EndTime != DateTime.MinValue; }
         }
 
         #region ISynchronizableWithLocalClock Members

--- a/src/EVEMon.Common/Serialization/Eve/SerializableQueuedSkill.cs
+++ b/src/EVEMon.Common/Serialization/Eve/SerializableQueuedSkill.cs
@@ -38,6 +38,13 @@ namespace EVEMon.Common.Serialization.Eve
             set { CCPEndTime = value.DateTimeToTimeString(); }
         }
 
+        // When the skill queue is paused, startTime and endTime are empty in the XML document
+        // As a result, the serialization leaves the DateTime with its default value
+        [XmlIgnore]
+        public bool IsPaused
+        {
+            get { return EndTime == DateTime.MinValue; }
+        }
 
         #region ISynchronizableWithLocalClock Members
 

--- a/src/EVEMon.Common/Serialization/Settings/SerializableSettings.cs
+++ b/src/EVEMon.Common/Serialization/Settings/SerializableSettings.cs
@@ -42,6 +42,8 @@ namespace EVEMon.Common.Serialization.Settings
         public string SSOClientID { get; set; }
         [XmlAttribute("clientSecret")]
         public string SSOClientSecret { get; set; }
+        [XmlAttribute("scopes")]
+        public string SSOScopes { get; set; }
 
         [XmlAttribute("revision")]
         public int Revision { get; set; }

--- a/src/EVEMon.Common/Service/SSOAuthenticationService.cs
+++ b/src/EVEMon.Common/Service/SSOAuthenticationService.cs
@@ -22,14 +22,13 @@ namespace EVEMon.Common.Service
         /// <returns>an instance of SSOAuthenticationService, or null if the settings are blank</returns>
         public static SSOAuthenticationService GetInstance()
         {
-            string id = Settings.SSOClientID, secret = Settings.SSOClientSecret;
+            string id = Settings.SSOClientID, secret = Settings.SSOClientSecret, scopes = Settings.SSOScopes;
             SSOAuthenticationService authService;
 
-            if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(secret))
+            if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(secret) || string.IsNullOrEmpty(scopes))
                 authService = null;
             else
-                authService = new SSOAuthenticationService(id, secret, NetworkConstants.
-                    SSOScopes);
+                authService = new SSOAuthenticationService(id, secret, scopes);
             return authService;
         }
 

--- a/src/EVEMon.Common/Settings.cs
+++ b/src/EVEMon.Common/Settings.cs
@@ -39,7 +39,7 @@ namespace EVEMon.Common
         {
             SSOClientID = string.Empty;
             SSOClientSecret = string.Empty;
-            SSOScopes = string.Empty;
+            SSOScopes = Constants.NetworkConstants.SSOScopes;
             UI = new UISettings();
             G15 = new G15Settings();
             Proxy = new ProxySettings();
@@ -199,7 +199,7 @@ namespace EVEMon.Common
                 // API settings
                 SSOClientID = s_settings.SSOClientID ?? string.Empty;
                 SSOClientSecret = s_settings.SSOClientSecret ?? string.Empty;
-                SSOScopes = s_settings.SSOScopes ?? string.Empty;
+                SSOScopes = !string.IsNullOrEmpty(s_settings.SSOScopes) ? s_settings.SSOScopes : Constants.NetworkConstants.SSOScopes;
 
                 // User settings
                 UI = s_settings.UI;

--- a/src/EVEMon.Common/Settings.cs
+++ b/src/EVEMon.Common/Settings.cs
@@ -39,6 +39,7 @@ namespace EVEMon.Common
         {
             SSOClientID = string.Empty;
             SSOClientSecret = string.Empty;
+            SSOScopes = string.Empty;
             UI = new UISettings();
             G15 = new G15Settings();
             Proxy = new ProxySettings();
@@ -81,6 +82,11 @@ namespace EVEMon.Common
         /// Gets or sets the SSO secret key.
         /// </summary>
         public static string SSOClientSecret { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the SSO scopes.
+        /// </summary>
+        public static string SSOScopes { get; private set; }
 
         /// <summary>
         /// Gets or sets the compatibility mode.
@@ -193,6 +199,7 @@ namespace EVEMon.Common
                 // API settings
                 SSOClientID = s_settings.SSOClientID ?? string.Empty;
                 SSOClientSecret = s_settings.SSOClientSecret ?? string.Empty;
+                SSOScopes = s_settings.SSOScopes ?? string.Empty;
 
                 // User settings
                 UI = s_settings.UI;
@@ -355,6 +362,7 @@ namespace EVEMon.Common
             {
                 SSOClientID = SSOClientID,
                 SSOClientSecret = SSOClientSecret,
+                SSOScopes = SSOScopes,
                 Revision = Revision,
                 Compatibility = Compatibility,
                 Scheduler = Scheduler.Export(),

--- a/src/EVEMon/ApiCredentialsManagement/EsiKeyUpdateOrAdditionWindow.cs
+++ b/src/EVEMon/ApiCredentialsManagement/EsiKeyUpdateOrAdditionWindow.cs
@@ -114,7 +114,7 @@ namespace EVEMon.ApiCredentialsManagement
 
             if (m_authService == null)
             {
-                MessageBox.Show(@"Please set the ESI Client ID and Client Secret in " +
+                MessageBox.Show(@"Please set the ESI Client ID, Client Secret and scopes in " +
                     "Settings > Network before adding ESI keys.", @"Client ID not set",
                     MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                 Close();

--- a/src/EVEMon/SettingsUI/SettingsForm.Designer.cs
+++ b/src/EVEMon/SettingsUI/SettingsForm.Designer.cs
@@ -227,6 +227,7 @@ namespace EVEMon.SettingsUI
             this.portableEveClientsControl = new EVEMon.SettingsUI.PortableEveClientsControl();
             this.cloudStorageServiceControl = new EVEMon.SettingsUI.CloudStorageServiceControl();
             this.settingsFileStorageControl = new EVEMon.SettingsUI.SettingsFileStorageControl();
+            this.insertAllScopesButton = new System.Windows.Forms.Button();
             this.systemTrayIconGroupBox.SuspendLayout();
             this.bottomPanel.SuspendLayout();
             this.CharacterMonitorGroupBox.SuspendLayout();
@@ -1310,6 +1311,7 @@ namespace EVEMon.SettingsUI
             // 
             // esiSettingsGroupBox
             // 
+            this.esiSettingsGroupBox.Controls.Add(this.insertAllScopesButton);
             this.esiSettingsGroupBox.Controls.Add(this.scopesTextBox);
             this.esiSettingsGroupBox.Controls.Add(this.lblScopes);
             this.esiSettingsGroupBox.Controls.Add(this.lblClientSecret);
@@ -1319,7 +1321,7 @@ namespace EVEMon.SettingsUI
             this.esiSettingsGroupBox.Controls.Add(this.clientIDTextBox);
             this.esiSettingsGroupBox.Location = new System.Drawing.Point(3, 194);
             this.esiSettingsGroupBox.Name = "esiSettingsGroupBox";
-            this.esiSettingsGroupBox.Size = new System.Drawing.Size(409, 111);
+            this.esiSettingsGroupBox.Size = new System.Drawing.Size(409, 137);
             this.esiSettingsGroupBox.TabIndex = 1;
             this.esiSettingsGroupBox.TabStop = false;
             this.esiSettingsGroupBox.Text = "ESI Client Settings";
@@ -1480,6 +1482,7 @@ namespace EVEMon.SettingsUI
             this.mailNotificationCheckBox.UseVisualStyleBackColor = true;
             this.mailNotificationCheckBox.CheckedChanged += new System.EventHandler(this.OnMustEnableOrDisable);
             // 
+            // emailNotificationsControl
             // notificationsPage
             // 
             this.notificationsPage.Controls.Add(this.lblNotificationsPage);
@@ -2304,6 +2307,19 @@ namespace EVEMon.SettingsUI
             this.settingsFileStorageControl.Size = new System.Drawing.Size(416, 108);
             this.settingsFileStorageControl.TabIndex = 0;
             // 
+            // insertAllScopesButton
+            // 
+            this.insertAllScopesButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.insertAllScopesButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.insertAllScopesButton.Location = new System.Drawing.Point(300, 109);
+            this.insertAllScopesButton.Margin = new System.Windows.Forms.Padding(3, 3, 3, 0);
+            this.insertAllScopesButton.Name = "insertAllScopesButton";
+            this.insertAllScopesButton.Size = new System.Drawing.Size(97, 23);
+            this.insertAllScopesButton.TabIndex = 6;
+            this.insertAllScopesButton.Text = "Insert all scopes";
+            this.insertAllScopesButton.UseVisualStyleBackColor = true;
+            this.insertAllScopesButton.Click += new System.EventHandler(this.insertAllScopesButton_Click);
+            // 
             // SettingsForm
             // 
             this.AcceptButton = this.okButton;
@@ -2571,5 +2587,6 @@ namespace EVEMon.SettingsUI
         private System.Windows.Forms.TextBox clientSecretTextBox;
         private System.Windows.Forms.TextBox scopesTextBox;
         private System.Windows.Forms.Label lblScopes;
+        private System.Windows.Forms.Button insertAllScopesButton;
     }
 }

--- a/src/EVEMon/SettingsUI/SettingsForm.Designer.cs
+++ b/src/EVEMon/SettingsUI/SettingsForm.Designer.cs
@@ -140,6 +140,8 @@ namespace EVEMon.SettingsUI
             this.cbHighlightPlannedSkills = new System.Windows.Forms.CheckBox();
             this.networkPage = new EVEMon.Common.Controls.MultiPanel.MultiPanelPage();
             this.esiSettingsGroupBox = new System.Windows.Forms.GroupBox();
+            this.scopesTextBox = new System.Windows.Forms.TextBox();
+            this.lblScopes = new System.Windows.Forms.Label();
             this.lblClientSecret = new System.Windows.Forms.Label();
             this.lblClientID = new System.Windows.Forms.Label();
             this.esiSettingsLabel = new System.Windows.Forms.LinkLabel();
@@ -1308,6 +1310,8 @@ namespace EVEMon.SettingsUI
             // 
             // esiSettingsGroupBox
             // 
+            this.esiSettingsGroupBox.Controls.Add(this.scopesTextBox);
+            this.esiSettingsGroupBox.Controls.Add(this.lblScopes);
             this.esiSettingsGroupBox.Controls.Add(this.lblClientSecret);
             this.esiSettingsGroupBox.Controls.Add(this.lblClientID);
             this.esiSettingsGroupBox.Controls.Add(this.esiSettingsLabel);
@@ -1315,10 +1319,26 @@ namespace EVEMon.SettingsUI
             this.esiSettingsGroupBox.Controls.Add(this.clientIDTextBox);
             this.esiSettingsGroupBox.Location = new System.Drawing.Point(3, 194);
             this.esiSettingsGroupBox.Name = "esiSettingsGroupBox";
-            this.esiSettingsGroupBox.Size = new System.Drawing.Size(409, 88);
+            this.esiSettingsGroupBox.Size = new System.Drawing.Size(409, 111);
             this.esiSettingsGroupBox.TabIndex = 1;
             this.esiSettingsGroupBox.TabStop = false;
             this.esiSettingsGroupBox.Text = "ESI Client Settings";
+            // 
+            // scopesTextBox
+            // 
+            this.scopesTextBox.Location = new System.Drawing.Point(82, 83);
+            this.scopesTextBox.Name = "scopesTextBox";
+            this.scopesTextBox.Size = new System.Drawing.Size(315, 20);
+            this.scopesTextBox.TabIndex = 9;
+            // 
+            // lblScopes
+            // 
+            this.lblScopes.AutoSize = true;
+            this.lblScopes.Location = new System.Drawing.Point(33, 86);
+            this.lblScopes.Name = "lblScopes";
+            this.lblScopes.Size = new System.Drawing.Size(43, 13);
+            this.lblScopes.TabIndex = 8;
+            this.lblScopes.Text = "Scopes";
             // 
             // lblClientSecret
             // 
@@ -2549,5 +2569,7 @@ namespace EVEMon.SettingsUI
         private System.Windows.Forms.Label lblClientSecret;
         private System.Windows.Forms.Label lblClientID;
         private System.Windows.Forms.TextBox clientSecretTextBox;
+        private System.Windows.Forms.TextBox scopesTextBox;
+        private System.Windows.Forms.Label lblScopes;
     }
 }

--- a/src/EVEMon/SettingsUI/SettingsForm.cs
+++ b/src/EVEMon/SettingsUI/SettingsForm.cs
@@ -1009,6 +1009,16 @@ namespace EVEMon.SettingsUI
             Util.OpenURL(new Uri(NetworkConstants.CCPApplicationRegistration));
         }
 
+        /// <summary>
+        /// General > Network > ESI Settings.
+        /// Fills out the SSO scopes setting with the defaultsd efined in NetworkConstants
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void insertAllScopesButton_Click(object sender, EventArgs e)
+        {
+            scopesTextBox.Text = NetworkConstants.SSOScopes;
+        }
         #endregion
     }
 }

--- a/src/EVEMon/SettingsUI/SettingsForm.cs
+++ b/src/EVEMon/SettingsUI/SettingsForm.cs
@@ -184,9 +184,10 @@ namespace EVEMon.SettingsUI
             proxyHttpHostTextBox.Text = m_settings.Proxy.Host;
             proxyAuthenticationButton.Tag = m_settings.Proxy;
 
-            // Client ID / Secret
+            // Client ID / Secret / Scopes
             clientIDTextBox.Text = m_settings.SSOClientID;
             clientSecretTextBox.Text = m_settings.SSOClientSecret;
+            scopesTextBox.Text = m_settings.SSOScopes;
 
             // Updates
             cbCheckTime.Checked = m_settings.Updates.CheckTimeOnStartup;
@@ -531,9 +532,10 @@ namespace EVEMon.SettingsUI
                 m_settings.Proxy.Port = proxyPort;
             m_settings.Proxy.Host = proxyHttpHostTextBox.Text;
 
-            // Client ID / Secret
+            // Client ID / Secret / Scopes
             m_settings.SSOClientID = (clientIDTextBox.Text ?? string.Empty).Trim();
             m_settings.SSOClientSecret = (clientSecretTextBox.Text ?? string.Empty).Trim();
+            m_settings.SSOScopes = (scopesTextBox.Text ?? string.Empty).Trim();
 
             // Updates
             m_settings.Updates.CheckEVEMonVersion = cbCheckForUpdates.Checked;


### PR DESCRIPTION
Added a setting for scopes - easy to fill out with "Copy scopes to clipboard" from the EVE Developer Application Settings.
Added a button for auto-filling the old definition.

The way the query monitors were chained after CharacterSheet meant that if just one of them failed, the rest wouldn't load.
Now they are all queried when their parent (CharacterSheet) is queried. Same principle applied to MailingLists.