### PR TITLE
Fix null ref if access response fails

### DIFF
--- a/src/EVEMon.Common/Service/SSOAuthenticationService.cs
+++ b/src/EVEMon.Common/Service/SSOAuthenticationService.cs
@@ -89,7 +89,7 @@ namespace EVEMon.Common.Service
                 ContinueWith((result) =>
                 {
                     var taskResult = result.Result;
-                    if (taskResult != null)
+                    if (taskResult != null && taskResult.Result != null)
                         // Initialize time since the deserializer does not call the constructor
                         taskResult.Result.Obtained = obtained;
                     Dispatcher.Invoke(() => callback?.Invoke(taskResult));


### PR DESCRIPTION
This could for example happen if the request times out or network connection drops.
Happened quite often when you set the http timeout to 1 second.