### PR TITLE
Fix research tab

### DIFF
--- a/src/EVEMon.Common/Serialization/Esi/EsiResearchListItem.cs
+++ b/src/EVEMon.Common/Serialization/Esi/EsiResearchListItem.cs
@@ -57,7 +57,8 @@ namespace EVEMon.Common.Serialization.Esi
                 AgentID = AgentID,
                 PointsPerDay = PointsPerDay,
                 RemainderPoints = RemainderPoints,
-                ResearchStartDate = ResearchStartDate
+                ResearchStartDate = ResearchStartDate,
+                SkillID = SkillID
             };
         }
     }


### PR DESCRIPTION
There is a NullReferenceException when trying to display the Research tab. It comes down to one property not correctly copied.