### PR TITLE
Fixed Skill Queue 'Training Time' spans to accurately reflect training times

### DIFF
--- a/src/EVEMon/CharacterMonitoring/CharacterSkillsQueueList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterSkillsQueueList.cs
@@ -230,9 +230,7 @@ namespace EVEMon.CharacterMonitoring
 
             Int64 skillPoints = (skill.Skill != null) && (skill.Level > skill.Skill.Level + 1)
                 ? skill.CurrentSP
-                : !hasSkill
-                    ? skill.StartSP
-                    : skill.Skill.SkillPoints;
+                : !hasSkill ? 0 : skill.StartSP;
             Int64 skillPointsToNextLevel = !hasSkill
                 ? skill.EndSP
                 : skill.Skill.StaticData.GetPointsRequiredForLevel(Math.Min(skill.Level, 5));


### PR DESCRIPTION
I noticed that some of the training times were off in the skill queue.  For whatever reason, skill.Skill.Skillpoints was returning a value that was inconsistent with the character's currently trained level.   Is this an issue with serialization? skill.Skill.Level was showing 3 for Capital Shield Operations and I hadn't started training in it yet.

Capital Shield I in the skill queue showed an SP of 64,000/2,000 and a negative training time of -1d -11h -1m -41s training time.
Capital Shield II SP: 64,000/11,314 and -1 -5h -45m 57s training time
Capital Shield III SP: 64,000/64,000 and (none) for training time
Capital Shield IV SP: 64,000/362,000 and 7d 23m 1s (the only correct one in the list with the original algorithm)