### PR TITLE
Fix an issue where implants would count double, if attributes got imp…

### DIFF
--- a/src/EVEMon.Common/Models/Character.cs
+++ b/src/EVEMon.Common/Models/Character.cs
@@ -837,7 +837,7 @@ namespace EVEMon.Common.Models
         /// Imports data from the given implants information.
         /// </summary>
         /// <param name="implants">The serialized implant information</param>
-        internal void Import(List<int> implants)
+        internal void Import(List<int> implants, EsiAPIAttributes attributes)
         {
             // Implants
             var newImplants = new LinkedList<SerializableNewImplant>();
@@ -848,6 +848,11 @@ namespace EVEMon.Common.Models
                     Name = StaticItems.GetItemName(implant)
                 });
             CurrentImplants.Import(newImplants);
+
+            // ESI reports implants as a part of attributes, so if attributes are imported before implants the implant bonus is added on top after implants are imported.
+            // Because of that, re-trigger attributes import after implant import, as it will subtract current implant bonus
+            if (attributes != null)
+                Import(attributes);
         }
 
         /// <summary>

--- a/src/EVEMon.Common/QueryMonitor/CharacterDataQuerying.cs
+++ b/src/EVEMon.Common/QueryMonitor/CharacterDataQuerying.cs
@@ -20,6 +20,8 @@ namespace EVEMon.Common.QueryMonitor
         private readonly CharacterQueryMonitor<EsiAPICharacterSheet> m_charSheetMonitor;
         private readonly CharacterQueryMonitor<EsiAPISkillQueue> m_charSkillQueueMonitor;
         private readonly CharacterQueryMonitor<EsiAPISkills> m_charSkillsMonitor;
+        private readonly CharacterQueryMonitor<List<int>> m_charImplantsMonitor;
+        private readonly CharacterQueryMonitor<EsiAPIAttributes> m_charAttributesMonitor;
         private readonly CharacterQueryMonitor<EsiAPIMarketOrders> m_charMarketOrdersMonitor;
         private readonly CharacterQueryMonitor<EsiAPIContracts> m_charContractsMonitor;
         private readonly CharacterQueryMonitor<EsiAPIIndustryJobs> m_charIndustryJobsMonitor;
@@ -57,13 +59,15 @@ namespace EVEMon.Common.QueryMonitor
                 ccpCharacter, ESIAPICharacterMethods.Clones, OnCharacterClonesUpdated,
                 notifiers.NotifyCharacterClonesError));
             // Implants
-            m_characterQueryMonitors.Add(new CharacterQueryMonitor<List<int>>(
+            m_charImplantsMonitor = new CharacterQueryMonitor<List<int>>(
                 ccpCharacter, ESIAPICharacterMethods.Implants, OnCharacterImplantsUpdated,
-                notifiers.NotifyCharacterImplantsError));
+                notifiers.NotifyCharacterImplantsError);
+            m_characterQueryMonitors.Add(m_charImplantsMonitor);
             // Attributes
-            m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIAttributes>(
+            m_charAttributesMonitor = new CharacterQueryMonitor<EsiAPIAttributes>(
                 ccpCharacter, ESIAPICharacterMethods.Attributes, OnCharacterAttributesUpdated,
-                notifiers.NotifyCharacterAttributesError));
+                notifiers.NotifyCharacterAttributesError);
+            m_characterQueryMonitors.Add(m_charAttributesMonitor);
             // Ship
             m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPIShip>(
                 ccpCharacter, ESIAPICharacterMethods.Ship, OnCharacterShipUpdated,
@@ -330,7 +334,7 @@ namespace EVEMon.Common.QueryMonitor
             // Character may have been deleted since we queried
             if (target != null)
             {
-                target.Import(result);
+                target.Import(result, m_charAttributesMonitor?.LastResult?.Result);
             }
         }
 


### PR DESCRIPTION
…orted before implants on initial import

This fixes an issue reported here https://github.com/peterhaneve/evemon/pull/6#issuecomment-390498490
It's related to the changes done here https://github.com/peterhaneve/evemon/commit/6a4659f01d8325183f1073395f6c5fc2ecc86e94 where the import expects attributes to already be loaded. But the new query monitor structure means that the order in which the calls complete is not fixed.

The issue is solved by triggering a re-import of the latest attribute result after a successful import of implants.