### PR TITLE
Fix balance, location, ship and employment history query monitors not querying

### DIFF
--- a/src/EVEMon.Common/Enumerations/CCPAPI/CCPAPIMethodsEnum.cs
+++ b/src/EVEMon.Common/Enumerations/CCPAPI/CCPAPIMethodsEnum.cs
@@ -16,25 +16,26 @@ namespace EVEMon.Common.Enumerations.CCPAPI
         BasicCharacterFeatures = ESIAPICharacterMethods.Attributes |
             ESIAPICharacterMethods.CharacterSheet | ESIAPICharacterMethods.Clones |
             ESIAPICharacterMethods.Implants | ESIAPICharacterMethods.SkillQueue |
-            ESIAPICharacterMethods.Skills,
+            ESIAPICharacterMethods.Skills | ESIAPICharacterMethods.AccountBalance |
+            ESIAPICharacterMethods.EmploymentHistory | ESIAPICharacterMethods.Location |
+            ESIAPICharacterMethods.Ship,
 
         /// <summary>
         /// The advanced character features of APIMethodsEnum.
         /// </summary>
-        AdvancedCharacterFeatures = ESIAPICharacterMethods.AccountBalance | ESIAPICharacterMethods.AssetList |
+        AdvancedCharacterFeatures = ESIAPICharacterMethods.AssetList |
             ESIAPICharacterMethods.CalendarEventAttendees | ESIAPICharacterMethods.ContactList |
             ESIAPICharacterMethods.Contracts | ESIAPICharacterMethods.ContractBids |
-            ESIAPICharacterMethods.ContractItems | ESIAPICharacterMethods.EmploymentHistory |
-            ESIAPICharacterMethods.FactionalWarfareStats | ESIAPICharacterMethods.IndustryJobs |
-            ESIAPICharacterMethods.JumpFatigue | ESIAPICharacterMethods.KillLog |
-            ESIAPICharacterMethods.Location | ESIAPICharacterMethods.MailMessages |
+            ESIAPICharacterMethods.ContractItems | ESIAPICharacterMethods.FactionalWarfareStats |
+            ESIAPICharacterMethods.IndustryJobs | ESIAPICharacterMethods.JumpFatigue |
+            ESIAPICharacterMethods.KillLog | ESIAPICharacterMethods.MailMessages |
             ESIAPICharacterMethods.MailBodies | ESIAPICharacterMethods.MailingLists |
             ESIAPICharacterMethods.MarketOrders | ESIAPICharacterMethods.Medals |
             ESIAPICharacterMethods.Notifications | ESIAPICharacterMethods.PlanetaryColonies |
             ESIAPICharacterMethods.PlanetaryLayout | ESIAPICharacterMethods.ResearchPoints |
-            ESIAPICharacterMethods.Ship | ESIAPICharacterMethods.Standings |
-            ESIAPICharacterMethods.UpcomingCalendarEvents | ESIAPICharacterMethods.UpcomingCalendarEventDetails |
-            ESIAPICharacterMethods.WalletJournal | ESIAPICharacterMethods.WalletTransactions,
+            ESIAPICharacterMethods.Standings | ESIAPICharacterMethods.UpcomingCalendarEvents |
+            ESIAPICharacterMethods.UpcomingCalendarEventDetails | ESIAPICharacterMethods.WalletJournal |
+            ESIAPICharacterMethods.WalletTransactions,
 
         /// <summary>
         /// The advanced corporation features of APIMethodsEnum.


### PR DESCRIPTION
Moved account balance, employment history, location and ship to BasicCharacterFeatures, so their query monitors become enabled.

Only character query monitors for ESIAPICharacterMethods included in CCPAPIMethodsEnum.BasicCharacterFeatures are added to the list of basic feature query monitors.
And only that list is subsequently enabled by default.

https://github.com/peterhaneve/evemon/blob/master/src/EVEMon.Common/QueryMonitor/CharacterDataQuerying.cs#L172
https://github.com/peterhaneve/evemon/blob/master/src/EVEMon.Common/QueryMonitor/CharacterDataQuerying.cs#L738

Issue reported here:
https://forums.eveonline.com/t/evemon-4-0-1-beta-under-new-ownership-conversion-for-esi/75953/97