### PR TITLE
Fix for EveMon's mainwindow disappearing multiple times in W10 Tablet Mode.

### DIFF
--- a/src/EVEMon.Common/Constants/NetworkConstants.resx
+++ b/src/EVEMon.Common/Constants/NetworkConstants.resx
@@ -461,10 +461,10 @@
     <value>http://api.eve-marketdata.com</value>
   </data>
   <data name="EVECentralAPIItemPrices" xml:space="preserve">
-    <value>/api/marketstat</value>
+    <value>/ec/marketstat</value>
   </data>
   <data name="EVECentralBaseUrl" xml:space="preserve">
-    <value>http://api.eve-central.com</value>
+    <value>https://api.evemarketer.com</value>
   </data>
   <data name="NISTTimeServer" xml:space="preserve">
     <value>tcp://time.nist.gov:13</value>

--- a/src/EVEMon.Common/Constants/NetworkConstants1.Designer.cs
+++ b/src/EVEMon.Common/Constants/NetworkConstants1.Designer.cs
@@ -19,7 +19,7 @@ namespace EVEMon.Common.Constants {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class NetworkConstants {
@@ -898,7 +898,7 @@ namespace EVEMon.Common.Constants {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to /api/marketstat.
+        ///   Looks up a localized string similar to /ec/marketstat.
         /// </summary>
         public static string EVECentralAPIItemPrices {
             get {
@@ -907,7 +907,7 @@ namespace EVEMon.Common.Constants {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to http://api.eve-central.com.
+        ///   Looks up a localized string similar to https://api.evemarketer.com.
         /// </summary>
         public static string EVECentralBaseUrl {
             get {

--- a/src/EVEMon.Common/MarketPricer/EveCentral/ECItemPricer.cs
+++ b/src/EVEMon.Common/MarketPricer/EveCentral/ECItemPricer.cs
@@ -31,7 +31,7 @@ namespace EVEMon.Common.MarketPricer.EveCentral
         /// <summary>
         /// Gets the name.
         /// </summary>
-        public override string Name => "EVE-Central";
+        public override string Name => "EVEMarketer";
 
         /// <summary>
         /// Gets a value indicating whether this <see cref="ItemPricer" /> is enabled.

--- a/src/EVEMon.Common/Serialization/EveCentral/MarketPricer/SerializableECItemPriceListItem.cs
+++ b/src/EVEMon.Common/Serialization/EveCentral/MarketPricer/SerializableECItemPriceListItem.cs
@@ -7,7 +7,7 @@ namespace EVEMon.Common.Serialization.EveCentral.MarketPricer
         [XmlAttribute("id")]
         public int ID { get; set; }
 
-        [XmlElement("all")]
+        [XmlElement("sell")]
         public SerializableECItemPriceItem Prices { get; set; }
     }
 }

--- a/src/EVEMon.Common/Serialization/EveCentral/MarketPricer/SerializableECItemPrices.cs
+++ b/src/EVEMon.Common/Serialization/EveCentral/MarketPricer/SerializableECItemPrices.cs
@@ -3,7 +3,7 @@ using System.Xml.Serialization;
 
 namespace EVEMon.Common.Serialization.EveCentral.MarketPricer
 {
-    [XmlRoot("evec_api")]
+    [XmlRoot("exec_api")]
     public sealed class SerializableECItemPrices
     {
         private readonly Collection<SerializableECItemPriceListItem> m_itemPrices;

--- a/src/EVEMon/About/AboutWindow.Designer.cs
+++ b/src/EVEMon/About/AboutWindow.Designer.cs
@@ -377,7 +377,7 @@ namespace EVEMon.About
             this.eveCentralLinkLabel.Padding = new System.Windows.Forms.Padding(5, 3, 0, 3);
             this.eveCentralLinkLabel.Size = new System.Drawing.Size(210, 19);
             this.eveCentralLinkLabel.TabIndex = 12;
-            this.eveCentralLinkLabel.Text = "EVE-Central for their market data and API.";
+            this.eveCentralLinkLabel.Text = "EVEMarketer for their market data and API.";
             this.eveCentralLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             // 
             // eveMarketDataLinkLabel

--- a/src/EVEMon/About/AboutWindow.cs
+++ b/src/EVEMon/About/AboutWindow.cs
@@ -193,7 +193,7 @@ namespace EVEMon.About
             AddLinkToLabel(ccpDocsLinkLabel, "CCP 3rd party docs", "https://eveonline-third-party-documentation.readthedocs.org/en/latest/");
             AddLinkToLabel(bitbucketLinkLabel, "Bitbucket", "https://bitbucket.org/");
             AddLinkToLabel(gitHubLinkLabel, "GitHub", "https://github.com/");
-            AddLinkToLabel(eveCentralLinkLabel, "EVE-Central", "http://www.eve-central.com/");
+            AddLinkToLabel(eveCentralLinkLabel, "EVEMarketer", "http://api.evemarketer.com/");
             AddLinkToLabel(eveMarketDataLinkLabel, "EVE-MarketData", "http://eve-marketdata.com/");
             AddLinkToLabel(googleApisLinkLabel, "Google", "https://github.com/google/google-api-dotnet-client/");
             AddLinkToLabel(dropboxSDKLinkLabel, "Dropbox", "https://github.com/dropbox/dropbox-sdk-dotnet/");

--- a/src/EVEMon/About/AboutWindow.cs
+++ b/src/EVEMon/About/AboutWindow.cs
@@ -193,7 +193,7 @@ namespace EVEMon.About
             AddLinkToLabel(ccpDocsLinkLabel, "CCP 3rd party docs", "https://eveonline-third-party-documentation.readthedocs.org/en/latest/");
             AddLinkToLabel(bitbucketLinkLabel, "Bitbucket", "https://bitbucket.org/");
             AddLinkToLabel(gitHubLinkLabel, "GitHub", "https://github.com/");
-            AddLinkToLabel(eveCentralLinkLabel, "EVEMarketer", "http://api.evemarketer.com/");
+            AddLinkToLabel(eveCentralLinkLabel, "EVEMarketer", "http://www.evemarketer.com/");
             AddLinkToLabel(eveMarketDataLinkLabel, "EVE-MarketData", "http://eve-marketdata.com/");
             AddLinkToLabel(googleApisLinkLabel, "Google", "https://github.com/google/google-api-dotnet-client/");
             AddLinkToLabel(dropboxSDKLinkLabel, "Dropbox", "https://github.com/dropbox/dropbox-sdk-dotnet/");

--- a/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.cs
@@ -1331,7 +1331,7 @@ namespace EVEMon.CharacterMonitoring
                 showOnlyCharMenuItem.Checked = contractsList.ShowIssuedFor == IssuedFor.Character;
             }
 
-            if (multiPanel.SelectedPage != jobsPage)
+            if (multiPanel.SelectedPage == jobsPage)
             {
                 jobsList.ShowIssuedFor = showOnlyCorpMenuItem.Checked ? IssuedFor.Corporation : IssuedFor.All;
                 showOnlyCharMenuItem.Checked = jobsList.ShowIssuedFor == IssuedFor.Character;

--- a/src/EVEMon/MainWindow.cs
+++ b/src/EVEMon/MainWindow.cs
@@ -403,6 +403,14 @@ namespace EVEMon {
         }
 
         /// <summary>
+        /// See MSDN.
+        /// </summary>
+        /// <param name="hWndLock"></param>
+        /// <returns></returns>
+        [DllImport("user32.dll")]
+        public static extern bool LockWindowUpdate(IntPtr hWndLock);
+
+        /// <summary>
         /// Updates the tab pages.
         /// </summary>
         private void UpdateTabs()
@@ -419,7 +427,7 @@ namespace EVEMon {
         /// </summary>
         private void LayoutTabPages()
         {
-            this.SuspendDrawing();
+            LockWindowUpdate(Handle);
 
             try
             {
@@ -480,7 +488,8 @@ namespace EVEMon {
             finally
             {
                 tcCharacterTabs.Visible = tcCharacterTabs.Controls.Count > 0;
-                this.ResumeDrawing();
+
+                LockWindowUpdate(IntPtr.Zero);
             }
         }
 


### PR DESCRIPTION
Fix for EveMon's mainwindow disappearing multiple times in W10 Tablet Mode caused by usage of Suspend/ResumeDrawing().
Replaced these methods by Win32 LockWindowUpdate() calls that behaves much better.