### PR TITLE
Fix extra skill completed notifications when queue is fully completed

### DIFF
--- a/src/EVEMon.Common/Models/Character.cs
+++ b/src/EVEMon.Common/Models/Character.cs
@@ -797,7 +797,7 @@ namespace EVEMon.Common.Models
 
             // Keep track of the current skill queue's completed skills, as ESI doesn't transfer them to the skills list until you login
             Dictionary<long, SerializableQueuedSkill> dict = new Dictionary<long, SerializableQueuedSkill>();
-            if (queue != null && IsTraining)
+            if (queue != null)
             {
                 foreach (var queuedSkill in queue.ToXMLItem().Queue)
                 {


### PR DESCRIPTION
If a queue is preset, use it no matter if character is training or not.
Each skill in queue is checked for being completed or training already.

This fixes an edge case which would cause extra skill completed notifications, if a character only had completed skills in the queue, and no new skills were added before next import.