### PR TITLE
Fix queue marked as paused but being empty.

### DIFF
--- a/src/EVEMon.Common/Models/SkillQueue.cs
+++ b/src/EVEMon.Common/Models/SkillQueue.cs
@@ -192,6 +192,10 @@ namespace EVEMon.Common.Models
             // Update skills with the imported data
             UpdateOnTimerTick();
 
+            // Skills may have been removed from the queue by the timer tick method - if it's empty, it's not paused
+            if (!Items.Any())
+                IsPaused = false;
+
             // Fires the event regarding the character skill queue update
             EveMonClient.OnCharacterSkillQueueUpdated(m_character);
         }


### PR DESCRIPTION
This should fix a null ref reported on the forums
https://forums.eveonline.com/t/evemon-4-0-1-beta-under-new-ownership-conversion-for-esi/75953/128

OverviewItem.cs would check if queue is paused, and then use CurrentlyTrainingSkill which would be null in some edge cases 
https://github.com/wbSD/evemon/blob/88d29162c1f480ee999fcea4991f1e4b21130037/src/EVEMon/Controls/OverviewItem.cs?utf8=%E2%9C%93#L330

I was able to reproduce the issue by importing a character with a paused skill in the queue, where the EndSP property was set higher than it could be for the level.
My theory is that CCP has some bugs with the skill queue API, as per https://www.reddit.com/r/Eve/comments/8maloe/psa_skillqueues_might_be_broken_for_some/