### PR TITLE
Handle SerializationException when ESI returns html response

### DIFF
--- a/src/EVEMon.Common/Serialization/JsonResult.cs
+++ b/src/EVEMon.Common/Serialization/JsonResult.cs
@@ -91,6 +91,16 @@ namespace EVEMon.Common.Serialization
         }
 
         /// <summary>
+        /// Constructor from a JSON serialization exception
+        /// </summary>
+        /// <param name="exception">The exception</param>
+        public JsonResult(SerializationException exception)
+            : this(exception as Exception)
+        {
+            m_error = APIErrorType.Json;
+        }
+
+        /// <summary>
         /// Constructor from a CCP API internal error
         /// </summary>
         /// <param name="code">The CCP error code.</param>

--- a/src/EVEMon.Common/Util.cs
+++ b/src/EVEMon.Common/Util.cs
@@ -508,6 +508,11 @@ namespace EVEMon.Common
                 result = new JsonResult<T>(e);
                 ExceptionHandler.LogException(e, true);
             }
+            catch (SerializationException e)
+            {
+                result = new JsonResult<T>(e);
+                ExceptionHandler.LogException(e, true);
+            }
             catch (APIException e)
             {
                 int code;
@@ -1108,6 +1113,10 @@ namespace EVEMon.Common
                     ExceptionHandler.LogException(e, true);
                 }
                 catch (InvalidDataContractException e)
+                {
+                    ExceptionHandler.LogException(e, true);
+                }
+                catch (SerializationException e)
                 {
                     ExceptionHandler.LogException(e, true);
                 }


### PR DESCRIPTION
When TQ is down for downtime, sometimes (for example during today's downtime) it starts returning 502 bad gateway. The ParseJSONObject method correctly identifies this as being an error (status code isn't 200), and then tries to deserialize the response into an EsiAPIError
However, the contents don't match that at all - 502 will return an html response (as seen below), which causes a SerializationException that isn't handled.

I've added a catch for that specifically, so now it will throw a HttpWebClientServiceException which is handled further up. I also added a catch and JsonResult constructor for that exception in DownloadJsonAsync, in case the responsecode is OK but the JSON still cannot be parsed.

`<html>`
`<head><title>502 Bad Gateway</title></head>`
`<body bgcolor="white">`
`<center><h1>502 Bad Gateway</h1></center>`
`</body>`
`</html>`