### PR TITLE
Fix null reference issues in assets/contracts windows if LastKnownLocation is null

### DIFF
--- a/src/EVEMon.Common/Models/Character.cs
+++ b/src/EVEMon.Common/Models/Character.cs
@@ -320,16 +320,14 @@ namespace EVEMon.Common.Models
         {
             get
             {
-                int id = LastKnownLocation.StationID;
-                return EveIDToStation.GetIDToStation(id != 0 ? id : LastKnownLocation.
-                    StructureID);
+                return EveIDToStation.GetIDToStation(LastKnownLocation?.StationID ?? LastKnownLocation?.StructureID ?? 0L);
             }
         }
 
         /// <summary>
         /// Gets the character's last known solar system location.
         /// </summary>
-        public SolarSystem LastKnownSolarSystem => StaticGeography.GetSolarSystemByID(LastKnownLocation.SolarSystemID);
+        public SolarSystem LastKnownSolarSystem => StaticGeography.GetSolarSystemByID(LastKnownLocation?.SolarSystemID ?? 0);
 
         /// <summary>
         /// Gets Alpha/Omega status for this character.


### PR DESCRIPTION
I found this because I was messing around with not providing all the scopes for #13 
If for some reason the LastKnownLocation of a character is null, it causes null reference a couple of places.
For example in the asset window when it tries to find out how many jumps away an asset is https://github.com/wbSD/evemon/blob/ba282a0218534013cb441baaa6c19c5d59de44c8/src/EVEMon.Common/Models/Collections/AssetCollection.cs#L74
The code expects LastKnownSolarSystem to return null if nothing is known, but a step in the ESI rewrite made LastKnownStation and LastKnownSolarSystem depend on LastKnownLocation being not null.

Both GetSolarSystemByID and GetIDToStation do a simple dictionary lookup by the value, so looking up 0 shouldn't be an issue.
The second step in GetIDToStation only tries to look up the structure id if it is `!= 0L`