### PR TITLE
Fixes an exception occuring during updating the OverviewItem content.

### DIFF
--- a/src/EVEMon.Common/Models/SkillQueue.cs
+++ b/src/EVEMon.Common/Models/SkillQueue.cs
@@ -129,6 +129,8 @@ namespace EVEMon.Common.Models
                 Items.RemoveAt(0);
             }
 
+            if (Items.Count == 0) IsPaused = false;
+
             if (skillsCompleted.Any() && !Settings.IsRestoring)
             {
                 // Send a notification, only if skills were completed


### PR DESCRIPTION
Fixed not setting paused to false when skill queue ends. How it would be after a fresh import of an empty skillqueue.

This fixes an exception caused by OverviewItem.UpdateContent where it tries to update the skillqueue states with the active skill when a skill queue is paused.
This should fix: https://forums.eveonline.com/t/evemon-4-0-2-beta-under-new-ownership-conversion-for-esi/75953/169