### PR TITLE
Fix exception when deleting a single remap point from a skill plan with the Delete key

### DIFF
--- a/src/EVEMon/SkillPlanner/PlanEditorControl.cs
+++ b/src/EVEMon/SkillPlanner/PlanEditorControl.cs
@@ -1205,6 +1205,12 @@ namespace EVEMon.SkillPlanner
             if (lvSkills.SelectedItems.Count == 0)
                 return;
 
+            if (lvSkills.SelectedItems.Count == 1 && lvSkills.SelectedItems[0].Tag is RemappingPoint)
+            {
+                tsbToggleRemapping_Click(null, null);
+                return;
+            }
+
             IPlanOperation operation = PrepareSelectionRemoval();
             if (operation == null)
                 return;
@@ -1615,12 +1621,7 @@ namespace EVEMon.SkillPlanner
         /// <param name="e"></param>
         private void miRemoveFromPlan_Click(object sender, EventArgs e)
         {
-            ListView.SelectedListViewItemCollection items = lvSkills.SelectedItems;
-
-            if (items.Count == 1 && items[0].Tag is RemappingPoint)
-                tsbToggleRemapping_Click(null, null);
-            else
-                RemoveSelectedEntries();
+            RemoveSelectedEntries();
         }
 
         /// <summary>


### PR DESCRIPTION
Moved the remapping point delete code from the right click handler to the remove entries method.
This makes it work both for right click -> remove from plan, and for selecting a remapping point in the list and clicking delete.

Issue was reported here:
https://forums.eveonline.com/t/evemon-4-0-2-beta-under-new-ownership-conversion-for-esi/75953/184

Note: If you select multiple rows, and the last item is a remapping point, it still won't be deleted.
That's because the remapping points are actually connected to the skill immediately after the remapping point, and the PlanOperation that is used when deleting skills does not currently have support for keeping track of remap points. It only keeps track of what skills to add/remove, so it will require a bigger change to fix that.