### PR TITLE
Use short circuit conditionals to optimize Mastery initialization

### DIFF
--- a/src/EVEMon.Common/Data/Mastery.cs
+++ b/src/EVEMon.Common/Data/Mastery.cs
@@ -139,9 +139,9 @@ namespace EVEMon.Common.Data
             foreach (SkillLevel prereqSkill in GetPrerequisiteSkills)
             {
                 // Trained only if the skill's level is greater or equal than the minimum level
-                trained &= prereqSkill.Skill.Level >= prereqSkill.Level;
+                trained = trained && prereqSkill.Skill.Level >= prereqSkill.Level;
 
-                noPrereq &= prereqSkill.AllDependencies.All(x => !x.IsTrained);
+                noPrereq = noPrereq && prereqSkill.AllDependencies.All(x => !x.IsTrained);
             }
 
             // Updates status

--- a/src/EVEMon.Common/Data/MasteryShip.cs
+++ b/src/EVEMon.Common/Data/MasteryShip.cs
@@ -91,7 +91,7 @@ namespace EVEMon.Common.Data
             while (true)
             {
                 bool updatedAnything = Items
-                    .Aggregate(false, (current, mastery) => current | mastery.TryUpdateMasteryStatus());
+                    .Aggregate(false, (current, mastery) => current || mastery.TryUpdateMasteryStatus());
 
                 if (!updatedAnything)
                     break;


### PR DESCRIPTION
While looking into what EVEMon is doing while loading characters, I noticed that more than 2.5 seconds of the load time was spent on initializing masteries when loading 10 characters.
By changing a few simple conditionals to short circuit (using `&&` instead of `&`) reduced the load time to 350 ms instead.

Below are screenshots from Visual Studio Diagnostic Tools, analyzing all the code that runs up until the OnCharaterCollectionChanged in GlobalCharacterCollection.cs line 163

The red square shows the CPU time and percentage of total for the Initialize method in the MasteryShip class (executed from MasteryShipCollection.cs line 35, and you can see a drop from 2700+ms and 20+% to around 350ms and only 3%

Before:
![image](https://user-images.githubusercontent.com/1277455/41206381-76a0cd70-6d03-11e8-99c8-64217caae985.png)

After:
![image](https://user-images.githubusercontent.com/1277455/41206383-7a568de2-6d03-11e8-9c55-2e0d08973c7f.png)
