### PR TITLE
Startup import performance improvements

### DIFF
--- a/src/EVEMon.Common/Collections/Global/GlobalCharacterCollection.cs
+++ b/src/EVEMon.Common/Collections/Global/GlobalCharacterCollection.cs
@@ -28,10 +28,11 @@ namespace EVEMon.Common.Collections.Global
         /// </summary>
         /// <param name="character"></param>
         /// <param name="notify"></param>
-        internal void Add(Character character, bool notify = true)
+        internal void Add(Character character, bool notify = true, bool setMonitored = true)
         {
             Items.Add(character);
-            character.Monitored = true;
+            if (setMonitored)
+                character.Monitored = true;
 
             if (notify)
                 EveMonClient.OnCharacterCollectionChanged();
@@ -151,7 +152,7 @@ namespace EVEMon.Common.Collections.Global
                 // Imports the character
                 SerializableCCPCharacter ccpCharacter = serialCharacter as SerializableCCPCharacter;
                 if (ccpCharacter != null)
-                    this.Add(new CCPCharacter(id, ccpCharacter));
+                    this.Add(new CCPCharacter(id, ccpCharacter), setMonitored: false);
                 else
                 {
                     SerializableUriCharacter uriCharacter = serialCharacter as SerializableUriCharacter;

--- a/src/EVEMon.Common/Collections/Global/GlobalCharacterCollection.cs
+++ b/src/EVEMon.Common/Collections/Global/GlobalCharacterCollection.cs
@@ -28,10 +28,12 @@ namespace EVEMon.Common.Collections.Global
         /// </summary>
         /// <param name="character"></param>
         /// <param name="notify"></param>
-        internal void Add(Character character, bool notify = true, bool setMonitored = true)
+        /// <param name="monitor"></param>
+        internal void Add(Character character, bool notify = true, bool monitor = true)
         {
             Items.Add(character);
-            if (setMonitored)
+
+            if (monitor)
                 character.Monitored = true;
 
             if (notify)
@@ -152,11 +154,11 @@ namespace EVEMon.Common.Collections.Global
                 // Imports the character
                 SerializableCCPCharacter ccpCharacter = serialCharacter as SerializableCCPCharacter;
                 if (ccpCharacter != null)
-                    this.Add(new CCPCharacter(id, ccpCharacter), setMonitored: false);
+                    this.Add(new CCPCharacter(id, ccpCharacter), false, false);
                 else
                 {
                     SerializableUriCharacter uriCharacter = serialCharacter as SerializableUriCharacter;
-                    this.Add(new UriCharacter(id, uriCharacter));
+                    this.Add(new UriCharacter(id, uriCharacter), false, false);
                 }
             }
 

--- a/src/EVEMon.Common/Collections/Global/GlobalMonitoredCharacterCollection.cs
+++ b/src/EVEMon.Common/Collections/Global/GlobalMonitoredCharacterCollection.cs
@@ -96,9 +96,9 @@ namespace EVEMon.Common.Collections.Global
                 Items.Add(character);
                 character.Monitored = true;
                 character.UISettings = characterSettings.Settings;
-            }
 
-            EveMonClient.OnMonitoredCharactersChanged();
+                EveMonClient.OnMonitoredCharactersChanged();
+            }
         }
 
         /// <summary>

--- a/src/EVEMon.Common/Collections/Global/GlobalMonitoredCharacterCollection.cs
+++ b/src/EVEMon.Common/Collections/Global/GlobalMonitoredCharacterCollection.cs
@@ -96,9 +96,9 @@ namespace EVEMon.Common.Collections.Global
                 Items.Add(character);
                 character.Monitored = true;
                 character.UISettings = characterSettings.Settings;
-
-                EveMonClient.OnMonitoredCharactersChanged();
             }
+
+            EveMonClient.OnMonitoredCharactersChanged();
         }
 
         /// <summary>


### PR DESCRIPTION
I looked into why the characters appear one at a time during startup, then all disappear and reappear one at a time.
They appear one at a time at first as a part of the import of SerializableSettings.Characters
https://github.com/peterhaneve/evemon/blob/5afb004a21dd6023bc14bf73adc0660f83230a7c/src/EVEMon.Common/Settings.cs#L250
At import, they are added one at a time to the GlobalCharacterCollection and marked as Monitored=true, which triggers OnMonitoredCharactersChanged() and adds the character to the GlobalMonitoredCharacterCollection.
https://github.com/peterhaneve/evemon/blob/5afb004a21dd6023bc14bf73adc0660f83230a7c/src/EVEMon.Common/Collections/Global/GlobalCharacterCollection.cs#L34
https://github.com/peterhaneve/evemon/blob/5afb004a21dd6023bc14bf73adc0660f83230a7c/src/EVEMon.Common/Models/Character.cs#L138
That in turn triggers the main window calling LayoutTabPages() which is what adds/removes the character tabs - one at a time.

After that, SerializableSettings.MonitoredCharacters are imported, which clears the GlobalMonitoredCharacterCollection, and then adds the monitored characters to it in a loop.
For some reason, the loop that adds them calls OnMonitoredCharactersChanged() once per character, which causes the tabs to appear - one at a time.
https://github.com/peterhaneve/evemon/blob/5afb004a21dd6023bc14bf73adc0660f83230a7c/src/EVEMon.Common/Collections/Global/GlobalMonitoredCharacterCollection.cs#L82
https://github.com/peterhaneve/evemon/blob/5afb004a21dd6023bc14bf73adc0660f83230a7c/src/EVEMon.Common/Collections/Global/GlobalMonitoredCharacterCollection.cs#L100


The changes in this pull request prevents that whole process from taking place twice, which for me with 10 characters (9 monitored) cuts several seconds off the startup time.
The time saved comes from not having to create all of the character tabs up to twice, and especially from not having to dispose all the tabs before recreating them (which is what currently happens in the LayoutTabPages() method once the first SeralizableSettings.MonitoredCharacters item is imported).

As far as I could see, it didn't have any negative CPU usage import.
It does have a funky side effect that the character pictures appear quickly, but the tabs don't appear until a few seconds later. I didn't look into why yet.