### PR TITLE
Implement expires and entity tag headers

### DIFF
--- a/src/EVEMon.Common/Extensions/TimeExtensions.cs
+++ b/src/EVEMon.Common/Extensions/TimeExtensions.cs
@@ -332,6 +332,11 @@ namespace EVEMon.Common.Extensions
             return offset.UtcDateTime;
         }
 
+        /// <summary>
+        /// Retrieves the Expires header value as a UTC DateTime
+        /// </summary>
+        /// <param name="headers"></param>
+        /// <returns></returns>
         public static DateTime? ExpiresTimeUTC(this HttpContentHeaders headers)
         {
             DateTimeOffset? offset = headers.Expires;

--- a/src/EVEMon.Common/Extensions/TimeExtensions.cs
+++ b/src/EVEMon.Common/Extensions/TimeExtensions.cs
@@ -331,5 +331,12 @@ namespace EVEMon.Common.Extensions
             DateTimeOffset offset = headers.Date ?? DateTimeOffset.UtcNow;
             return offset.UtcDateTime;
         }
+
+        public static DateTime? ExpiresTimeUTC(this HttpContentHeaders headers)
+        {
+            DateTimeOffset? offset = headers.Expires;
+
+            return offset?.UtcDateTime;
+        }
     }
 }

--- a/src/EVEMon.Common/Models/APIProvider.cs
+++ b/src/EVEMon.Common/Models/APIProvider.cs
@@ -140,10 +140,11 @@ namespace EVEMon.Common.Models
         /// <param name="method"></param>
         /// <param name="callback">The callback to invoke once the query has been completed.</param>
         /// <param name="state">State to be passed to the callback when it is used.</param>
+        /// <param name="eTag">The previous result's entity tag, if applicable.</param>
         public void QueryEsiAsync<T>(Enum method, ESIRequestCallback<T> callback,
-            object state = null) where T : class
+            object state = null, string eTag = null) where T : class
         {
-            QueryEsiAsync(method, callback, state, new EsiParams());
+            QueryEsiAsync(method, callback, state, new EsiParams() { ETag = eTag });
         }
 
         /// <summary>
@@ -154,10 +155,11 @@ namespace EVEMon.Common.Models
         /// <param name="id">The ID to query.</param>
         /// <param name="callback">The callback to invoke once the query has been completed.</param>
         /// <param name="state">State to be passed to the callback when it is used.</param>
+        /// <param name="eTag">The previous result's entity tag, if applicable.</param>
         public void QueryEsiAsync<T>(Enum method, long id, ESIRequestCallback<T> callback,
-            object state = null) where T : class
+            object state = null, string eTag = null) where T : class
         {
-            QueryEsiAsync(method, callback, state, new EsiParams() { ParamOne = id });
+            QueryEsiAsync(method, callback, state, new EsiParams() { ParamOne = id, ETag = eTag });
         }
 
         /// <summary>
@@ -169,12 +171,13 @@ namespace EVEMon.Common.Models
         /// <param name="data">The string query data for the second GET parameter.</param>
         /// <param name="callback">The callback to invoke once the query has been completed.</param>
         /// <param name="state">State to be passed to the callback when it is used.</param>
+        /// <param name="eTag">The previous result's entity tag, if applicable.</param>
         public void QueryEsiAsync<T>(Enum method, long id, string data,
-            ESIRequestCallback<T> callback, object state = null) where T : class
+            ESIRequestCallback<T> callback, object state = null, string eTag = null) where T : class
         {
             QueryEsiAsync(method, callback, state, new EsiParams()
             {
-                ParamOne = id, GetData = data
+                ParamOne = id, GetData = data, ETag = eTag
             });
         }
 
@@ -186,10 +189,11 @@ namespace EVEMon.Common.Models
         /// <param name="postData">The data to submit in the POST body.</param>
         /// <param name="callback">The callback to invoke once the query has been completed.</param>
         /// <param name="state">State to be passed to the callback when it is used.</param>
+        /// <param name="eTag">The previous result's entity tag, if applicable.</param>
         public void QueryEsiAsync<T>(Enum method, string postData, ESIRequestCallback<T> callback,
-            object state = null) where T : class
+            object state = null, string eTag = null) where T : class
         {
-            QueryEsiAsync(method, callback, state, new EsiParams() { PostData = postData });
+            QueryEsiAsync(method, callback, state, new EsiParams() { PostData = postData, ETag = eTag });
         }
 
         /// <summary>
@@ -200,12 +204,13 @@ namespace EVEMon.Common.Models
         /// <param name="id">The ID to query.</param>
         /// <param name="callback">The callback to invoke once the query has been completed.</param>
         /// <param name="state">State to be passed to the callback when it is used.</param>
+        /// <param name="eTag">The previous result's entity tag, if applicable.</param>
         public void QueryEsiAsync<T>(Enum method, string token, long id, ESIRequestCallback<T> callback,
-            object state = null) where T : class
+            object state = null, string eTag = null) where T : class
         {
             QueryEsiAsync(method, callback, state, new EsiParams()
             {
-                Token = token, ParamOne = id
+                Token = token, ParamOne = id, ETag = eTag
             });
         }
 
@@ -218,12 +223,13 @@ namespace EVEMon.Common.Models
         /// <param name="id">The ID to query.</param>
         /// <param name="callback">The callback to invoke once the query has been completed.</param>
         /// <param name="state">State to be passed to the callback when it is used.</param>
+        /// <param name="eTag">The previous result's entity tag, if applicable.</param>
         public void QueryEsiAsync<T>(Enum method, string token, long character, long id,
-            ESIRequestCallback<T> callback, object state = null) where T : class
+            ESIRequestCallback<T> callback, object state = null, string eTag = null) where T : class
         {
             QueryEsiAsync(method, callback, state, new EsiParams()
             {
-                Token = token, ParamOne = character, ParamTwo = id
+                Token = token, ParamOne = character, ParamTwo = id, ETag = eTag
             });
         }
 
@@ -250,7 +256,7 @@ namespace EVEMon.Common.Models
             // Lazy download
             Uri url = GetESIUrl(method, data.ParamOne, data.ParamTwo, data.GetData);
 
-            Util.DownloadJsonAsync<T>(url, data.Token, SupportsCompressedResponse, data.PostData)
+            Util.DownloadJsonAsync<T>(url, data.Token, SupportsCompressedResponse, data.PostData, eTag: data.ETag)
                 .ContinueWith(task =>
                 {
                     var esiResult = new EsiResult<T>(task.Result);
@@ -293,6 +299,7 @@ namespace EVEMon.Common.Models
             public string GetData;
             public string PostData;
             public string Token;
+            public string ETag;
         }
 
         #endregion

--- a/src/EVEMon.Common/Net/DownloadResult.cs
+++ b/src/EVEMon.Common/Net/DownloadResult.cs
@@ -28,6 +28,7 @@ namespace EVEMon.Common.Net
         /// <param name="error">The error.</param>
         /// <param name="responseCode">The server response code.</param>
         /// <param name="serverTime">The time on the server.</param>
+        /// <param name="eTag">The previous result's entity tag, if applicable.</param>
         public DownloadResult(T result, HttpWebClientServiceException error, int responseCode,
             DateTime serverTime, DateTime? expires = null, string eTag = null)
         {

--- a/src/EVEMon.Common/Net/DownloadResult.cs
+++ b/src/EVEMon.Common/Net/DownloadResult.cs
@@ -29,12 +29,13 @@ namespace EVEMon.Common.Net
         /// <param name="responseCode">The server response code.</param>
         /// <param name="serverTime">The time on the server.</param>
         public DownloadResult(T result, HttpWebClientServiceException error, int responseCode,
-            DateTime serverTime)
+            DateTime serverTime, DateTime? expires = null)
         {
             Error = error;
             Result = result;
             ResponseCode = responseCode;
             ServerTime = serverTime;
+            Expires = expires;
         }
 
         /// <summary>
@@ -60,5 +61,7 @@ namespace EVEMon.Common.Net
         /// </summary>
         /// <value>The time on the server, in UTC.</value>
         public DateTime ServerTime { get; }
+
+        public DateTime? Expires { get; }
     }
 }

--- a/src/EVEMon.Common/Net/DownloadResult.cs
+++ b/src/EVEMon.Common/Net/DownloadResult.cs
@@ -29,13 +29,14 @@ namespace EVEMon.Common.Net
         /// <param name="responseCode">The server response code.</param>
         /// <param name="serverTime">The time on the server.</param>
         public DownloadResult(T result, HttpWebClientServiceException error, int responseCode,
-            DateTime serverTime, DateTime? expires = null)
+            DateTime serverTime, DateTime? expires = null, string eTag = null)
         {
             Error = error;
             Result = result;
             ResponseCode = responseCode;
             ServerTime = serverTime;
             Expires = expires;
+            ETag = eTag;
         }
 
         /// <summary>
@@ -66,5 +67,11 @@ namespace EVEMon.Common.Net
         /// The time at which the result expires
         /// </summary>
         public DateTime? Expires { get; }
+
+        /// <summary>
+        /// Entity Tag value - used for If-None-Match header
+        /// https://developers.eveonline.com/blog/article/esi-etag-best-practices
+        /// </summary>
+        public string ETag { get; }
     }
 }

--- a/src/EVEMon.Common/Net/DownloadResult.cs
+++ b/src/EVEMon.Common/Net/DownloadResult.cs
@@ -62,6 +62,9 @@ namespace EVEMon.Common.Net
         /// <value>The time on the server, in UTC.</value>
         public DateTime ServerTime { get; }
 
+        /// <summary>
+        /// The time at which the result expires
+        /// </summary>
         public DateTime? Expires { get; }
     }
 }

--- a/src/EVEMon.Common/Net/HttpWebClientService.StreamDownload.cs
+++ b/src/EVEMon.Common/Net/HttpWebClientService.StreamDownload.cs
@@ -73,6 +73,7 @@ namespace EVEMon.Common.Net
             HttpWebClientServiceException error = null;
             int responseCode = (int)response.StatusCode;
             DateTime serverTime = response.Headers.ServerTimeUTC();
+            DateTime? expires = response.Content?.Headers?.ExpiresTimeUTC();
 
             if (stream == null)
                 // No stream (can this happen)?
@@ -82,7 +83,7 @@ namespace EVEMon.Common.Net
                 // Attempt to invoke parser
                 result = parser.Invoke(Util.ZlibUncompress(stream), responseCode);
 
-            return new DownloadResult<T>(result, error, responseCode, serverTime);
+            return new DownloadResult<T>(result, error, responseCode, serverTime, expires);
         }
     }
 }

--- a/src/EVEMon.Common/QueryMonitor/CharacterQueryMonitor.cs
+++ b/src/EVEMon.Common/QueryMonitor/CharacterQueryMonitor.cs
@@ -73,7 +73,7 @@ namespace EVEMon.Common.QueryMonitor
         {
             provider.ThrowIfNull(nameof(provider));
 
-            provider.QueryEsiAsync(Method, m_apiKey.AccessToken, m_character.CharacterID, callback);
+            provider.QueryEsiAsync(Method, m_apiKey.AccessToken, m_character.CharacterID, callback, eTag: LastResult?.ETag);
         }
     }
 }

--- a/src/EVEMon.Common/QueryMonitor/QueryMonitor.cs
+++ b/src/EVEMon.Common/QueryMonitor/QueryMonitor.cs
@@ -258,7 +258,7 @@ namespace EVEMon.Common.QueryMonitor
         {
             provider.ThrowIfNull(nameof(provider));
 
-            provider.QueryEsiAsync(Method, callback);
+            provider.QueryEsiAsync(Method, callback, eTag: LastResult?.ETag);
         }
 
         /// <summary>
@@ -280,6 +280,11 @@ namespace EVEMon.Common.QueryMonitor
             // Updates the stored data
             m_retryOnForceUpdateError = false;
             LastUpdate = DateTime.UtcNow;
+
+            // If the result didn't change, re-use previous result
+            if (result.ResponseCode == (int)System.Net.HttpStatusCode.NotModified)
+                result.Result = LastResult.Result;
+
             LastResult = result;
 
             // Notify subscribers

--- a/src/EVEMon.Common/Serialization/Esi/EsiResult.cs
+++ b/src/EVEMon.Common/Serialization/Esi/EsiResult.cs
@@ -16,7 +16,7 @@ namespace EVEMon.Common.Serialization.Eve
         /// </summary>
         public EsiResult(int responseCode, T result = default(T)) : base(responseCode, result)
         {
-            CachedUntil = CurrentTime;
+            CachedUntil = Expires ?? CurrentTime;
         }
         
         /// <summary>
@@ -25,7 +25,7 @@ namespace EVEMon.Common.Serialization.Eve
         /// <param name="exception">The exception.</param>
         public EsiResult(HttpWebClientServiceException exception) : base(exception)
         {
-            CachedUntil = CurrentTime;
+            CachedUntil = Expires ?? CurrentTime;
         }
         
         /// <summary>
@@ -34,7 +34,7 @@ namespace EVEMon.Common.Serialization.Eve
         /// <param name="wrapped">The result to wrap.</param>
         public EsiResult(JsonResult<T> wrapped) : base(wrapped)
         {
-            CachedUntil = wrapped.CurrentTime;
+            CachedUntil = wrapped.Expires ?? wrapped.CurrentTime;
         }
 
         #endregion

--- a/src/EVEMon.Common/Serialization/JsonResult.cs
+++ b/src/EVEMon.Common/Serialization/JsonResult.cs
@@ -59,6 +59,7 @@ namespace EVEMon.Common.Serialization
             Result = wrapped.Result;
             CurrentTime = wrapped.CurrentTime;
             Expires = wrapped.Expires;
+            ETag = wrapped.ETag;
         }
 
         /// <summary>
@@ -148,6 +149,8 @@ namespace EVEMon.Common.Serialization
         public DateTime CurrentTime { get; set; }
 
         public DateTime? Expires { get; set; }
+
+        public string ETag { get; set; }
 
         #endregion
         

--- a/src/EVEMon.Common/Serialization/JsonResult.cs
+++ b/src/EVEMon.Common/Serialization/JsonResult.cs
@@ -58,6 +58,7 @@ namespace EVEMon.Common.Serialization
             m_responseCode = wrapped.ResponseCode;
             Result = wrapped.Result;
             CurrentTime = wrapped.CurrentTime;
+            Expires = wrapped.Expires;
         }
 
         /// <summary>
@@ -145,6 +146,8 @@ namespace EVEMon.Common.Serialization
         public T Result { get; set; }
 
         public DateTime CurrentTime { get; set; }
+
+        public DateTime? Expires { get; set; }
 
         #endregion
         

--- a/src/EVEMon.Common/Util.cs
+++ b/src/EVEMon.Common/Util.cs
@@ -495,7 +495,8 @@ namespace EVEMon.Common
                     result = new JsonResult<T>(new InvalidOperationException("null JSON response"));
                 else
                     result = new JsonResult<T>(asyncResult.ResponseCode, data) {
-                        CurrentTime = asyncResult.ServerTime
+                        CurrentTime = asyncResult.ServerTime,
+                        Expires = asyncResult.Expires
                     };
             }
             catch (InvalidOperationException e)


### PR DESCRIPTION
- Expires response header is now used
The ESI results were previously marked as CachedUntil the time they were received, which wasn't correct.
Now it looks for the Expires header in the response, and uses the value provided from there.
Among other things, this makes the NextUpdate property on QueryMonitor become the time when the server cache expires (unless the update period says to update it after the expiry time)

- ETag response header is now stored and re-used to reduce bandwidth usage
The ESI responses contain an ETag header which can be sent back to the server on subsequent queries.
If the data has not been modified, the server responds with 304 Not Modified and no content, which conserves bandwidth and signals to re-use the previous result.
https://developers.eveonline.com/blog/article/esi-etag-best-practices
I had to drag the entity tag all the way from QueryMonitor.LastResult into the HttpClientServiceRequest and back out. If you see an easier/better way of doing it than what I've implemented here, feedback is very welcome.