### PR TITLE
ETag null ref fix: Only run if result has data

### DIFF
--- a/src/EVEMon.Common/QueryMonitor/QueryMonitor.cs
+++ b/src/EVEMon.Common/QueryMonitor/QueryMonitor.cs
@@ -275,7 +275,8 @@ namespace EVEMon.Common.QueryMonitor
                 LastResult = result;
                 m_lastResponse = result.Response;
                 // Notify subscribers
-                m_onUpdated?.Invoke(result);
+                if (result.HasData)
+                    m_onUpdated?.Invoke(result);
             }
         }
 


### PR DESCRIPTION
This is easy to reproduce, just make the server status query monitor run again.