### PR TITLE
Fix capitalization issues preventing compilation

### DIFF
--- a/src/EVEMon.Common/Properties/Resources.resx
+++ b/src/EVEMon.Common/Properties/Resources.resx
@@ -239,7 +239,7 @@
     <value>..\Resources\Cursors\ContextMenuPointer.cur;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="RefTypes" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\serialization\reftypes.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+    <value>..\Serialization\RefTypes.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
   <data name="CallbackFail" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\callback_fail.htm;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
@@ -248,7 +248,7 @@
     <value>..\Resources\callback_ok.htm;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
   <data name="chrFactions" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\chrfactions.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>..\Resources\chrFactions.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="ErrorAccountBalance" xml:space="preserve">
     <value>Error querying the wallet balance for {0}.</value>


### PR DESCRIPTION
Fix incorrectly capitalized paths in a file causing compilation to fail
on Linux (where filenames are case-sensitive).