### PR TITLE
Bugfixes/esi lookups skipped

### DIFF
--- a/src/EVEMon.Common/Service/EveIDToStation.cs
+++ b/src/EVEMon.Common/Service/EveIDToStation.cs
@@ -286,15 +286,25 @@ namespace EVEMon.Common.Service
                                     ParamOne = id
                                 }, new CitadelQueryInfo(id, esiKey));
                         }
-#if HAMMERTIME
                         else
                         {
-                            lock(FailedHammertimeIds)
+#if HAMMERTIME
+                            lock (FailedHammertimeIds)
                                 if (!FailedHammertimeIds.Contains(id))
                                     LoadCitadelInformationFromHammertimeAPI(id);
-                        }
+                                else
+                                    OnLookupComplete();
+#else
+                            // we move on to the next request
+                            OnLookupComplete();
 #endif
+                        }
                     }
+                }
+                else // this should not happen but lets be sure
+                {
+                    // move on to the next request
+                    OnLookupComplete();
                 }
             }
 


### PR DESCRIPTION
Hello, currently my esi citadel implementation fails to lookup citadels again with esi if previously (because lack up api key provided) it only did it with hammertime.
This is a fix for it.
Also I added that it relooksup citadel info on esi where it failed previously under a different apikey.
These 2 things are in different commits, so easy for me to just make a different pullrequest with only one if them if you don't like both.