### PR TITLE
1) Supressed two exception

### DIFF
--- a/src/EVEMon.Common/Controls/NoFlickerListBox.cs
+++ b/src/EVEMon.Common/Controls/NoFlickerListBox.cs
@@ -51,6 +51,9 @@ namespace EVEMon.Common.Controls
                 case (int)WM.WM_ERASEBKGND:
                     PaintNonItemRegion();
                     m.Msg = (int)WM.WM_NULL;
+                    m.LParam = IntPtr.Zero;
+                    m.WParam = IntPtr.Zero;
+                    m.Result = IntPtr.Zero;
                     break;
             }
             base.WndProc(ref m);

--- a/src/EVEMon/Controls/ReadingPane.Designer.cs
+++ b/src/EVEMon/Controls/ReadingPane.Designer.cs
@@ -62,6 +62,7 @@ namespace EVEMon.Controls
             this.wbMailBody.ScriptErrorsSuppressed = true;
             this.wbMailBody.Size = new System.Drawing.Size(257, 81);
             this.wbMailBody.TabIndex = 2;
+            this.wbMailBody.Url = new System.Uri("about:blank\r", System.UriKind.Absolute);
             this.wbMailBody.WebBrowserShortcutsEnabled = false;
             this.wbMailBody.Navigating += new System.Windows.Forms.WebBrowserNavigatingEventHandler(this.wbMailBody_Navigating);
             this.wbMailBody.PreviewKeyDown += new System.Windows.Forms.PreviewKeyDownEventHandler(this.wbMailBody_PreviewKeyDown);


### PR DESCRIPTION
1) Suppressed invalid URL exception when empty text is loaded into the mail reading pane by setting initial design time url to "about:blank".
2) Supressed Invalid Parameter exception by setting all msg parameters to zero.

Note for 1) this fix may apply to other usage of embedded browser as well.
Note for 2) a return instead of a break in the case statement is probably just as good as the caught windows message is handled.