### PR TITLE
Fixed display of character on overview click

### DIFF
--- a/src/EVEMon/MainWindow.cs
+++ b/src/EVEMon/MainWindow.cs
@@ -629,6 +629,7 @@ namespace EVEMon
                     tab => tab.character == e.Character).Select(character => character.tab))
             {
                 tcCharacterTabs.SelectedTab = tab;
+                UpdateControlsOnTabSelectionChange();
                 return;
             }
         }


### PR DESCRIPTION
* Fixed the display of the correct tab. It was only selected if clicked on the overview, but not displayed.