### PR TITLE
Put "Inaccessible structure" in a solar system (fix #62)

### DIFF
--- a/src/EVEMon.Common/Data/Constellation.cs
+++ b/src/EVEMon.Common/Data/Constellation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using EVEMon.Common.Collections;
+using EVEMon.Common.Constants;
 using EVEMon.Common.Extensions;
 using EVEMon.Common.Serialization.Datafiles;
 
@@ -36,7 +37,7 @@ namespace EVEMon.Common.Data
         public Constellation()
         {
             ID = 0;
-            Name = "unknown";
+            Name = EveMonConstants.UnknownText;
             Region = new Region();
         }
         #endregion

--- a/src/EVEMon.Common/Data/Region.cs
+++ b/src/EVEMon.Common/Data/Region.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using EVEMon.Common.Collections;
+using EVEMon.Common.Constants;
 using EVEMon.Common.Extensions;
 using EVEMon.Common.Serialization.Datafiles;
 
@@ -31,7 +32,7 @@ namespace EVEMon.Common.Data
         internal Region()
         {
             ID = 0;
-            Name = "unknown";
+            Name = EveMonConstants.UnknownText;
         }
         #endregion
 

--- a/src/EVEMon.Common/Data/SolarSystem.cs
+++ b/src/EVEMon.Common/Data/SolarSystem.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using EVEMon.Common.Collections;
+using EVEMon.Common.Constants;
 using EVEMon.Common.Enumerations;
 using EVEMon.Common.Extensions;
 using EVEMon.Common.Helpers;
@@ -70,7 +71,7 @@ namespace EVEMon.Common.Data
             ID = 0;
             Constellation = new Constellation();
             SecurityLevel = 0.0F;
-            FullLocation = "";
+            FullLocation = EveMonConstants.UnknownText;
         }
         #endregion
 

--- a/src/EVEMon.Common/Data/Station.cs
+++ b/src/EVEMon.Common/Data/Station.cs
@@ -26,7 +26,7 @@ namespace EVEMon.Common.Data
                 StationID = id,
                 StationName = "Inaccessible Structure",
                 StationTypeID = 35832 // Astrahus
-            });
+            }, new SolarSystem());
         }
 
         #region Constructor
@@ -46,6 +46,12 @@ namespace EVEMon.Common.Data
             CorporationName = src.CorporationName;
             SolarSystem = StaticGeography.GetSolarSystemByID(src.SolarSystemID);
             FullLocation = GetFullLocation(SolarSystem, src.StationName);
+        }
+
+        private Station(SerializableOutpost src, SolarSystem owner)
+            : this(src)
+        {
+            SolarSystem = SolarSystem ?? owner;
         }
 
         /// <summary>

--- a/src/EVEMon.Common/Data/Station.cs
+++ b/src/EVEMon.Common/Data/Station.cs
@@ -48,10 +48,16 @@ namespace EVEMon.Common.Data
             FullLocation = GetFullLocation(SolarSystem, src.StationName);
         }
 
-        private Station(SerializableOutpost src, SolarSystem owner)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Station"/> class.
+        /// </summary>
+        /// <param name="src">The source.</param>
+        /// <param name="fallback">Solar system to fall back to,
+        /// if the source solar system cannot be found</param>
+        private Station(SerializableOutpost src, SolarSystem fallback)
             : this(src)
         {
-            SolarSystem = SolarSystem ?? owner;
+            SolarSystem = SolarSystem ?? fallback;
         }
 
         /// <summary>

--- a/src/EVEMon.Common/Models/Character.cs
+++ b/src/EVEMon.Common/Models/Character.cs
@@ -545,7 +545,7 @@ namespace EVEMon.Common.Models
             // In a station ?
             // Don't care if it's an outpost or regular station
             // as station name will be displayed in docking info
-            if (station != null)
+            if (station?.SolarSystem != null)
                 return $"{station.SolarSystem.FullLocation} ({station.SolarSystem.SecurityLevel:N1})";
 
             // Has to be in a solar system at least


### PR DESCRIPTION
The first commit fixes #62 by preventing the null reference that occurs due to the "Inaccessible structure" having a solar system id of 0, and therefore SolarSystem = null.

However there are many places in the code that use Station.SolarSystem without checking for null (for example contracts and market orders), so it might be a good idea to cover those cases as well.
The other commits ensure that the "Inaccessible structure" solar system will not be null (it becomes `new SolarSystem()` instead).

Take or leave whichever solution is preferred, both of them fix the issue on their own.