### PR TITLE
Fix cast exception when double clicking certificate level

### DIFF
--- a/src/EVEMon/SkillPlanner/CertificateTreeDisplayControl.cs
+++ b/src/EVEMon/SkillPlanner/CertificateTreeDisplayControl.cs
@@ -647,10 +647,13 @@ namespace EVEMon.SkillPlanner
         /// <param name="e"></param>
         private void showInBrowserMenu_Click(object sender, EventArgs e)
         {
-            Skill skill = ((SkillLevel)treeView.SelectedNode?.Tag)?.Skill;
-
-            // Open the skill browser
-            PlanWindow.ShowPlanWindow(m_character, m_plan).ShowSkillInBrowser(skill);
+            Skill skill;
+            if (treeView.SelectedNode?.Tag is SkillLevel skillLevel
+                && (skill = skillLevel?.Skill) != null)
+            {
+                // Open the skill browser
+                PlanWindow.ShowPlanWindow(m_character, m_plan).ShowSkillInBrowser(skill);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes a crash that was reported on the evemondevteam repository
https://github.com/evemondevteam/evemon/issues/62