### PR TITLE
1) Fix for incorrectly marking all MarketOrders as Character ones

### DIFF
--- a/src/EVEMon.Common/Models/CCPCharacter.cs
+++ b/src/EVEMon.Common/Models/CCPCharacter.cs
@@ -883,11 +883,21 @@ namespace EVEMon.Common.Models
         {
             if (e.Character == this)
             {
-                m_jobsCompletedForCharacter.AddRange(e.CompletedJobs);
+                // veg Fix 4
+                foreach (IndustryJob job in e.CompletedJobs)
+                {
+                    if (!m_jobsCompletedForCharacter.Any(p => p.ID == job.ID))
+                    {
+                        m_jobsCompletedForCharacter.Add(job);
+                    }
+                }
 
                 // If character has completed corporation issued jobs, wait until those are gathered too
-                if (!CorporationIndustryJobs.Any(job => job.ActiveJobState ==
-                        ActiveJobState.Ready && !job.NotificationSend))
+                // 
+                // veg Fix 5
+                // 
+                if (m_jobsCompletedForCharacter.Any(job => job.ActiveJobState ==
+                                        ActiveJobState.Ready && !job.NotificationSend))
                 {
                     EveMonClient.Notifications.NotifyCharacterIndustryJobCompletion(this,
                         m_jobsCompletedForCharacter);

--- a/src/EVEMon.Common/Models/MarketOrder.cs
+++ b/src/EVEMon.Common/Models/MarketOrder.cs
@@ -36,12 +36,16 @@ namespace EVEMon.Common.Models
         /// character.</param>
         /// <param name="character">The owning character.</param>
         /// <exception cref="System.ArgumentNullException">src</exception>
-        protected MarketOrder(EsiOrderListItem src, IssuedFor issuedFor,
-            CCPCharacter character)
+            protected MarketOrder(EsiOrderListItem src, IssuedFor issuedFor,
+                CCPCharacter character)
         {
             src.ThrowIfNull(nameof(src));
 
             PopulateOrderInfo(src, issuedFor);
+
+                // veg Fix #1
+                issuedFor = src.IsCorporation || src.IssuedBy == 0  ? IssuedFor.Corporation : IssuedFor.Character;
+
             LastStateChange = DateTime.UtcNow;
             m_character = character;
             m_state = GetState(src);
@@ -275,7 +279,8 @@ namespace EVEMon.Common.Models
             MinVolume = src.MinVolume;
             Duration = src.Duration;
             Issued = src.Issued;
-            IssuedFor = issuedFor;
+            // veg Fix #2
+            IssuedFor = src.IsCorporation || src.IssuedBy == 0 ? IssuedFor.Corporation : IssuedFor.Character;
             m_stationID = src.StationID;
             UpdateStation();
 

--- a/src/EVEMon.Common/Serialization/Esi/EsiOrderListItem.cs
+++ b/src/EVEMon.Common/Serialization/Esi/EsiOrderListItem.cs
@@ -67,37 +67,37 @@ namespace EVEMon.Common.Serialization.Esi
             {
                 switch (State)
                 {
-                case 1:
-                    return "closed";
-                case 2:
-                    return "expired";
-                case 3:
-                    return "cancelled";
-                default:
-                    // Active in ESI is simply not shown
-                    return default(string);
+                    case 1:
+                        return "closed";
+                    case 2:
+                        return "expired";
+                    case 3:
+                        return "cancelled";
+                    default:
+                        // Active in ESI is simply not shown
+                        return default(string);
                 }
             }
             set
             {
                 switch (value)
                 {
-                case "active":
-                case "":
-                case null:
-                    State = 0;
-                    break;
-                case "closed":
-                    State = 1;
-                    break;
-                case "expired":
-                    State = 2;
-                    break;
-                case "cancelled":
-                    State = 3;
-                    break;
-                default:
-                    break;
+                    case "active":
+                    case "":
+                    case null:
+                        State = 0;
+                        break;
+                    case "closed":
+                        State = 1;
+                        break;
+                    case "expired":
+                        State = 2;
+                        break;
+                    case "cancelled":
+                        State = 3;
+                        break;
+                    default:
+                        break;
                 }
             }
         }
@@ -126,21 +126,21 @@ namespace EVEMon.Common.Serialization.Esi
                 // Converts to legacy XML value
                 switch (value)
                 {
-                case "station":
-                    Range = -1;
-                    break;
-                case "solarsystem":
-                    Range = 0;
-                    break;
-                case "region":
-                    Range = EveConstants.RegionRange;
-                    break;
-                default:
-                    // Cannot actually fail, but the exception would suck
-                    if (value.TryParseInv(out jumps) && jumps > 0 && jumps < EveConstants.
-                            RegionRange)
-                        Range = jumps;
-                    break;
+                    case "station":
+                        Range = -1;
+                        break;
+                    case "solarsystem":
+                        Range = 0;
+                        break;
+                    case "region":
+                        Range = EveConstants.RegionRange;
+                        break;
+                    default:
+                        // Cannot actually fail, but the exception would suck
+                        if (value.TryParseInv(out jumps) && jumps > 0 && jumps < EveConstants.
+                                RegionRange)
+                            Range = jumps;
+                        break;
                 }
             }
         }
@@ -179,6 +179,14 @@ namespace EVEMon.Common.Serialization.Esi
         [DataMember(Name = "is_buy_order")]
         public bool IsBuyOrder { get; set; }
 
+        // veg Fix #3
+
+        /// <summary>
+        /// True if this is a corporation order, false otherwise.
+        /// </summary>
+        [DataMember(Name = "is_corporation")]
+        public bool IsCorporation { get; set; }
+
         /// <summary>
         /// The character ID who issued this order.
         /// </summary>
@@ -196,7 +204,7 @@ namespace EVEMon.Common.Serialization.Esi
                 return issued;
             }
         }
-        
+
         [DataMember(Name = "issued")]
         private string IssuedJson
         {


### PR DESCRIPTION
See Issue #77 for a explanation of commit a679389. 

It is probably also a good idea to remove the unused & hardcoded **IssueFor** parameter from the affected/involved methods.

The changes in EsiOrderListItem.cs  also contain some source formatting (sorry).