### PR TITLE
Fix #82 completed industry job notification

### DIFF
--- a/src/EVEMon.Common/Models/Collections/IndustryJobCollection.cs
+++ b/src/EVEMon.Common/Models/Collections/IndustryJobCollection.cs
@@ -85,15 +85,18 @@ namespace EVEMon.Common.Models.Collections
             {
                 DateTime limit = job.EndDate.AddDays(IndustryJob.MaxEndedDays);
                 // For jobs which are not yet ended, or are active and not ready (active is
-                // defined as having an empty completion date), and are not already in list
+                // defined as having an empty completion date)
                 if (limit >= now || (job.CompletedDate == DateTime.MinValue && job.Status !=
-                    CCPJobCompletedStatus.Ready) && !Items.Any(x => x.TryImport(job, issuedFor,
-                    m_ccpCharacter)))
+                    CCPJobCompletedStatus.Ready))
                 {
-                    // Only add jobs with valid items
-                    var ij = new IndustryJob(job, issuedFor);
-                    if (ij.InstalledItem != null && ij.OutputItem != null)
-                        newJobs.AddLast(ij);
+                    // Where the job isn't already in the list
+                    if (!Items.Any(x => x.TryImport(job, issuedFor, m_ccpCharacter)))
+                    {
+                        // Only add jobs with valid items
+                        var ij = new IndustryJob(job, issuedFor);
+                        if (ij.InstalledItem != null && ij.OutputItem != null)
+                            newJobs.AddLast(ij);
+                    }
                 }
             }
             // Add the items that are no longer marked for deletion


### PR DESCRIPTION
There was a bug introduced where the TryImport method wasn't used if `limit >= now`
It could be fixed simply by adding some parenthesis, but I put the TryImport call on its own line instead to indicate its significance.

Compare that to how the code looked before the ESI rewrite:
https://github.com/peterhaneve/evemon/blob/9db4f30aceff8745d5ee0c30178b34f182fec452/src/EVEMon.Common/Models/Collections/IndustryJobCollection.cs#L100-L104
Here the TryImport is in a separate .Where lambda expression, which means it used to also be checked for jobs where `limit >= now`