### PR TITLE
fix for status detection and learning expectations

### DIFF
--- a/src/EVEMon.Common/Models/AccountStatus.cs
+++ b/src/EVEMon.Common/Models/AccountStatus.cs
@@ -6,7 +6,8 @@ namespace EVEMon.Common.Models
     {
         public enum AccountStatusType { Unknown, Alpha, Omega };
         
-        private const float trainingRateUnknown = 1.0f;
+        // pessimist mode on.
+        private const float trainingRateUnknown = 0.5f;
         private const float trainingRateAlpha = 0.5f;
         private const float trainingRateOmega = 1.0f;
 

--- a/src/EVEMon.Common/Models/Character.cs
+++ b/src/EVEMon.Common/Models/Character.cs
@@ -91,51 +91,57 @@ namespace EVEMon.Common.Models
         public void UpdateAccountStatus(AccountStatusType status = AccountStatusType.Unknown)
         {
             var skill = CurrentlyTrainingSkill;
+            var skillIsTraining = (skill != null) && skill.IsTraining;
 
-            if (skill != null && skill.IsTraining)
+            if (skillIsTraining && SkillPoints > EveConstants.MaxAlphaSkillTraining)
             {
-                if (SkillPoints > EveConstants.MaxAlphaSkillTraining)
+                status = AccountStatusType.Omega;
+            }
+            else
+            {
+                foreach(var sk in Skills)
                 {
-                    status = AccountStatusType.Omega;
+                    // Is the skill level being limited by alpha status?
+                    if(sk.ActiveLevel < sk.Level)
+                    {
+                        // Active level is being limited by alpha status.
+                        status = AccountStatusType.Alpha;
+                        break;
+                    }
+                    // Has the skill alpha limit been exceeded?
+                    if(sk.ActiveLevel > sk.StaticData.AlphaLimit)
+                    {
+                        // Active level is greater than alpha limit, only on Omega.
+                        status = AccountStatusType.Omega;
+                        break;
+                    }
                 }
-                else
+                if(status == AccountStatusType.Unknown && skillIsTraining)
                 {
                     // Try to determine account status based on training time
                     var hoursToTrain = (skill.EndTime - skill.StartTime).TotalHours;
+                    var secondsToTrain = (skill.EndTime - skill.StartTime).TotalSeconds;
                     var spToTrain = skill.EndSP - skill.StartSP;
-                    if (hoursToTrain > 0 && spToTrain > 0)
+                    // training time formula requirenment: 6 seconds.
+                    // jitter for EndTime and StartTime: 2 seconds.
+                    if (secondsToTrain > (6 + 2) && spToTrain > 0)
                     {
-                        // spPerHour must be greater than zero since both the numerator and
-                        // denominator are
+                        // spPerHour must be greater than zero since numerator and denominator are
                         var spPerHour = spToTrain / hoursToTrain;
                         double rate = GetOmegaSPPerHour(skill.Skill) / spPerHour;
-                        // Allow for small margin of error
+                        // Allow for small margin of error, important on skills nearing completion.
                         if (rate < 1.2 && rate > 0.8)
+                        {
                             status = AccountStatusType.Omega;
+                        }
                         else if (rate > 1.1)
+                        {
                             status = AccountStatusType.Alpha;
+                        }
                     }
                 }
             }
-
-            foreach (var sk in Skills)
-            {
-                // Is the skill level being limited by alpha status?
-                if (sk.ActiveLevel < sk.Level)
-                {
-                    // Active level is being limited by alpha status.
-                    status = AccountStatusType.Alpha;
-                    break;
-                }
-                // Has the skill alpha limit been exceeded?
-                if (sk.ActiveLevel > sk.StaticData.AlphaLimit)
-                {
-                    // Active level is greater than alpha limit, only on Omega.
-                    status = AccountStatusType.Omega;
-                    break;
-                }
-            }
-
+            
             CharacterStatus = new AccountStatus(status);
         }
 


### PR DESCRIPTION
- Establish chain of tests for status update (without rewrites of gotten result).
- Move training speed test to last position as it relies on Attributes data with longest cache.
- Increase time condition for training speed test (to avoid wrong result for skill near completion).
- Use Alpha training speed rate for calculations during Unknown character status.

