### PR TITLE
Adjust scrollbars after running the custom layout. Fix #110

### DIFF
--- a/src/EVEMon/Controls/Overview.cs
+++ b/src/EVEMon/Controls/Overview.cs
@@ -337,6 +337,8 @@ namespace EVEMon.Controls
                 }
 
                 labelNoCharacters.Visible = !EveMonClient.MonitoredCharacters.Any();
+
+                base.AdjustFormScrollbars(true);
             }
             finally
             {


### PR DESCRIPTION
The solution seems almost too easy.
This fixes the scrollbar issues mentioned in #110 - I am not able to reproduce it at all after adding this line of code.

P.S. The reason the scrollbar maximum height went up so much when the client was minimized was because ClientSize.Height and Width goes to 0 when it's minimized. That causes PerformCustomLayout to only use 1 column instead of 2 (in my example), meaning that the total height doubled.