### PR TITLE
Format absolute percentage with the same number of decimals as modifier percentages

### DIFF
--- a/src/EVEMon.Common/Data/EveProperty.cs
+++ b/src/EVEMon.Common/Data/EveProperty.cs
@@ -196,11 +196,11 @@ namespace EVEMon.Common.Data
 
                         // Format a value of Absolute Percentage
                     case DBConstants.AbsolutePercentUnitID:
-                        return $"{numericValue * 100} {Unit}";
+                        return $"{numericValue * 100:0.###} {Unit}";
 
                         // Format a value of Inverse Absolute Percentage
                     case DBConstants.InverseAbsolutePercentUnitID:
-                        return $"{(1 - numericValue) * 100} {Unit}";
+                        return $"{(1 - numericValue) * 100:0.###} {Unit}";
 
                         // Format a value of Modifier Percentage
                     case DBConstants.ModifierPercentUnitID:


### PR DESCRIPTION
This will fix #105 
I chose to just re-use the string format options used by the next 2 cases in the switch.
The reason it formatted with many decimal places is because numericValue is float - it causes the value to become imprecise.
For example 1 - 0.95F = 0.0500000119

Another approach could maybe be to determine the number of decimal places used by the input and then round the calculated value to that number of decimal places.
https://stackoverflow.com/questions/13477689/find-number-of-decimal-places-in-decimal-value-regardless-of-culture