### PR TITLE
Try to fix blueprint xml

### DIFF
--- a/src/EVEMon.Common/Data/Blueprint.cs
+++ b/src/EVEMon.Common/Data/Blueprint.cs
@@ -7,7 +7,7 @@ namespace EVEMon.Common.Data
 {
     public class Blueprint : Item
     {
-        private readonly Dictionary<int, double> m_inventBlueprints;
+        private readonly Dictionary<int, decimal> m_inventBlueprints;
         private readonly FastList<StaticRequiredMaterial> m_materialRequirements;
 
 
@@ -31,7 +31,7 @@ namespace EVEMon.Common.Data
             ReverseEngineeringTime = src.ReverseEngineeringTime;
 
             // Invented blueprints
-            m_inventBlueprints = new Dictionary<int, double>(src.InventionTypeIDs?.Count ?? 0);
+            m_inventBlueprints = new Dictionary<int, decimal>(src.InventionTypeIDs?.Count ?? 0);
             if (src.InventionTypeIDs != null && src.InventionTypeIDs.Any())
             {
                 m_inventBlueprints.AddRange(src.InventionTypeIDs);
@@ -102,9 +102,9 @@ namespace EVEMon.Common.Data
         /// <summary>
         /// Gets the collection of blueprints this object can invent.
         /// </summary>
-        public IEnumerable<KeyValuePair<Blueprint, double>> InventBlueprints
+        public IEnumerable<KeyValuePair<Blueprint, decimal>> InventBlueprints
             => m_inventBlueprints
-                .Select(inventBlueprint => new KeyValuePair<Blueprint, double>(
+                .Select(inventBlueprint => new KeyValuePair<Blueprint, decimal>(
                     StaticBlueprints.GetBlueprintByID(inventBlueprint.Key), inventBlueprint.Value));
 
         #endregion

--- a/src/EVEMon.Common/Serialization/Datafiles/SerializableBlueprint.cs
+++ b/src/EVEMon.Common/Serialization/Datafiles/SerializableBlueprint.cs
@@ -22,7 +22,7 @@ namespace EVEMon.Common.Serialization.Datafiles
         /// </summary>
         public SerializableBlueprint()
         {
-            InventionTypeIDs = new ModifiedSerializableDictionary<int, double>();
+            InventionTypeIDs = new ModifiedSerializableDictionary<int, decimal>();
             m_prereqSkills = new Collection<SerializablePrereqSkill>();
             m_requiredMaterials = new Collection<SerializableRequiredMaterial>();
         }
@@ -116,7 +116,7 @@ namespace EVEMon.Common.Serialization.Datafiles
         /// </summary>
         /// <value>The invention type ID.</value>
         [XmlElement("inventTypeIDs")]
-        public ModifiedSerializableDictionary<int, double> InventionTypeIDs { get; set; }
+        public ModifiedSerializableDictionary<int, decimal> InventionTypeIDs { get; set; }
 
         /// <summary>
         /// Gets the prereq skill.

--- a/src/EVEMon/SkillPlanner/BlueprintBrowserControl.cs
+++ b/src/EVEMon/SkillPlanner/BlueprintBrowserControl.cs
@@ -259,7 +259,7 @@ namespace EVEMon.SkillPlanner
 
             // Invented blueprints
             InventBlueprintListBox.Items.Clear();
-            foreach (KeyValuePair<Blueprint, double> item in m_blueprint.InventBlueprints)
+            foreach (KeyValuePair<Blueprint, decimal> item in m_blueprint.InventBlueprints)
             {
                 InventBlueprintListBox.Items.Add(item.Key);
             }
@@ -268,7 +268,7 @@ namespace EVEMon.SkillPlanner
             lblSuccessProbability.Visible = lblProbability.Visible = m_blueprint.InventBlueprints.Any();
             if (lblProbability.Visible)
             {
-                Double baseProbability = m_blueprint.InventBlueprints.Max(x => x.Value);
+                decimal baseProbability = m_blueprint.InventBlueprints.Max(x => x.Value);
                 lblProbability.Text = $"{baseProbability:P1} (You: {baseProbability * GetProbabilityModifier():P1})";
             }
 
@@ -666,18 +666,18 @@ namespace EVEMon.SkillPlanner
         /// Gets the probability modifier.
         /// </summary>
         /// <returns></returns>
-        private double GetProbabilityModifier()
+        private decimal GetProbabilityModifier()
         {
             if (Character == null)
-                return 1d;
+                return 1M;
 
-            const Double BonusFactor = 0.05d;
-            Double skillLevel = m_blueprint.Prerequisites
+            const decimal BonusFactor = 0.05M;
+            decimal skillLevel = m_blueprint.Prerequisites
                 .Where(x => x.Activity == BlueprintActivity.Invention || x.Activity == BlueprintActivity.ReverseEngineering)
                 .Where(x => x.Skill != null)
                 .Max(x => Character.Skills[x.Skill.ID].LastConfirmedLvl);
 
-            return 1d + BonusFactor * skillLevel;
+            return 1M + BonusFactor * skillLevel;
         }
 
         /// <summary>

--- a/tools/XmlGenerator/Datafiles/Blueprints.cs
+++ b/tools/XmlGenerator/Datafiles/Blueprints.cs
@@ -1,563 +1,563 @@
-﻿//using System;
-//using System.Collections.Generic;
-//using System.Diagnostics;
-//using System.Linq;
-//using EVEMon.Common.Collections;
-//using EVEMon.Common.Constants;
-//using EVEMon.Common.Enumerations;
-//using EVEMon.Common.Serialization.Datafiles;
-//using EVEMon.XmlGenerator.Interfaces;
-//using EVEMon.XmlGenerator.Providers;
-//using EVEMon.XmlGenerator.StaticData;
-//using EVEMon.XmlGenerator.Utils;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using EVEMon.Common.Collections;
+using EVEMon.Common.Constants;
+using EVEMon.Common.Enumerations;
+using EVEMon.Common.Serialization.Datafiles;
+using EVEMon.XmlGenerator.Interfaces;
+using EVEMon.XmlGenerator.Providers;
+using EVEMon.XmlGenerator.StaticData;
+using EVEMon.XmlGenerator.Utils;
 
-//namespace EVEMon.XmlGenerator.Datafiles
-//{
-//    internal static class Blueprints
-//    {
-//        private static List<InvMarketGroups> s_injectedMarketGroups;
-//        private static List<InvTypes> s_nullMarketBlueprints;
+namespace EVEMon.XmlGenerator.Datafiles
+{
+    internal static class Blueprints
+    {
+        private static List<InvMarketGroups> s_injectedMarketGroups;
+        private static List<InvTypes> s_nullMarketBlueprints;
 
-//        /// <summary>
-//        /// Generate the skills datafile.
-//        /// </summary>
-//        internal static void GenerateDatafile()
-//        {
-//            Stopwatch stopwatch = Stopwatch.StartNew();
-//            Util.ResetCounters();
+        /// <summary>
+        /// Generate the skills datafile.
+        /// </summary>
+        internal static void GenerateDatafile()
+        {
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            Util.ResetCounters();
 
-//            Console.WriteLine();
-//            Console.Write(@"Generating blueprints datafile... ");
+            Console.WriteLine();
+            Console.Write(@"Generating blueprints datafile... ");
 
-//            // Configure blueprints with Null market group
-//            ConfigureNullMarketBlueprint();
+            // Configure blueprints with Null market group
+            ConfigureNullMarketBlueprint();
 
-//            Dictionary<int, SerializableBlueprintMarketGroup> groups = new Dictionary<int, SerializableBlueprintMarketGroup>();
+            Dictionary<int, SerializableBlueprintMarketGroup> groups = new Dictionary<int, SerializableBlueprintMarketGroup>();
 
-//            // Export blueprint groups           
-//            CreateMarketGroups(groups);
+            // Export blueprint groups           
+            CreateMarketGroups(groups);
 
-//            // Create the parent-children groups relations
-//            foreach (SerializableBlueprintMarketGroup group in groups.Values)
-//            {
-//                IEnumerable<SerializableBlueprintMarketGroup> children = Database.InvMarketGroupsTable.Concat(
-//                    s_injectedMarketGroups).Where(x => x.ParentID == group.ID).Select(
-//                        x => groups[x.ID]).OrderBy(x => x.Name);
+            // Create the parent-children groups relations
+            foreach (SerializableBlueprintMarketGroup group in groups.Values)
+            {
+                IEnumerable<SerializableBlueprintMarketGroup> children = Database.InvMarketGroupsTable.Concat(
+                    s_injectedMarketGroups).Where(x => x.ParentID == group.ID).Select(
+                        x => groups[x.ID]).OrderBy(x => x.Name);
 
-//                group.SubGroups.AddRange(children);
-//            }
+                group.SubGroups.AddRange(children);
+            }
 
-//            // Sort groups
-//            IEnumerable<SerializableBlueprintMarketGroup> blueprintGroups = Database.InvMarketGroupsTable.Concat(
-//                s_injectedMarketGroups).Where(x => x.ParentID == DBConstants.BlueprintsMarketGroupID).Select(
-//                    x => groups[x.ID]).OrderBy(x => x.Name);
+            // Sort groups
+            IEnumerable<SerializableBlueprintMarketGroup> blueprintGroups = Database.InvMarketGroupsTable.Concat(
+                s_injectedMarketGroups).Where(x => x.ParentID == DBConstants.BlueprintsMarketGroupID).Select(
+                    x => groups[x.ID]).OrderBy(x => x.Name);
 
-//            // Reset the custom market groups
-//            s_nullMarketBlueprints.ForEach(srcItem => srcItem.MarketGroupID = null);
-//            Database.InvTypesTable
-//                .Where(item => Database.InvGroupsTable[item.GroupID].CategoryID == DBConstants.AncientRelicsCategoryID)
-//                .ToList()
-//                .ForEach(x => x.MarketGroupID = DBConstants.AncientRelicsMarketGroupID);
+            // Reset the custom market groups
+            s_nullMarketBlueprints.ForEach(srcItem => srcItem.MarketGroupID = null);
+            Database.InvTypesTable
+                .Where(item => Database.InvGroupsTable[item.GroupID].CategoryID == DBConstants.AncientRelicsCategoryID)
+                .ToList()
+                .ForEach(x => x.MarketGroupID = DBConstants.AncientRelicsMarketGroupID);
 
-//            // Serialize
-//            BlueprintsDatafile datafile = new BlueprintsDatafile();
-//            datafile.MarketGroups.AddRange(blueprintGroups);
+            // Serialize
+            BlueprintsDatafile datafile = new BlueprintsDatafile();
+            datafile.MarketGroups.AddRange(blueprintGroups);
 
-//            Util.DisplayEndTime(stopwatch);
+            Util.DisplayEndTime(stopwatch);
 
-//            // DEBUG: Find which blueprints have not been generated
-//            if (Debugger.IsAttached)
-//            {
-//                var blueprintIds = groups.Values.SelectMany(x => x.Blueprints).Select(y => y.ID).ToList();
-//                var diff = Database.InvBlueprintTypesTable.Where(blueprint => !blueprintIds.Contains(blueprint.ID)).ToList();
+            // DEBUG: Find which blueprints have not been generated
+            if (Debugger.IsAttached)
+            {
+                var blueprintIds = groups.Values.SelectMany(x => x.Blueprints).Select(y => y.ID).ToList();
+                var diff = Database.InvBlueprintTypesTable.Where(blueprint => !blueprintIds.Contains(blueprint.ID)).ToList();
 
-//                if (diff.Any())
-//                    Console.WriteLine("{0} blueprints were not generated.", diff.Count);
-//            }
+                if (diff.Any())
+                    Console.WriteLine("{0} blueprints were not generated.", diff.Count);
+            }
 
-//            Util.SerializeXml(datafile, DatafileConstants.BlueprintsDatafile);
-//        }
+            Util.SerializeXml(datafile, DatafileConstants.BlueprintsDatafile);
+        }
 
-//        /// <summary>
-//        /// Creates the market groups.
-//        /// </summary>
-//        /// <param name="groups">The groups.</param>
-//        private static void CreateMarketGroups(IDictionary<int, SerializableBlueprintMarketGroup> groups)
-//        {
-//            foreach (InvMarketGroups marketGroup in Database.InvMarketGroupsTable.Concat(s_injectedMarketGroups))
-//            {
-//                SerializableBlueprintMarketGroup group = new SerializableBlueprintMarketGroup
-//                {
-//                    ID = marketGroup.ID,
-//                    Name = marketGroup.Name,
-//                };
+        /// <summary>
+        /// Creates the market groups.
+        /// </summary>
+        /// <param name="groups">The groups.</param>
+        private static void CreateMarketGroups(IDictionary<int, SerializableBlueprintMarketGroup> groups)
+        {
+            foreach (InvMarketGroups marketGroup in Database.InvMarketGroupsTable.Concat(s_injectedMarketGroups))
+            {
+                SerializableBlueprintMarketGroup group = new SerializableBlueprintMarketGroup
+                {
+                    ID = marketGroup.ID,
+                    Name = marketGroup.Name,
+                };
 
-//                groups[marketGroup.ID] = group;
+                groups[marketGroup.ID] = group;
 
-//                // Add the items in this group
-//                List<SerializableBlueprint> blueprints = new List<SerializableBlueprint>();
-//                foreach (InvTypes item in Database.InvTypesTable.Where(
-//                    item => item.MarketGroupID.GetValueOrDefault() == marketGroup.ID &&
-//                            (Database.InvGroupsTable[item.GroupID].CategoryID == DBConstants.BlueprintCategoryID ||
-//                             Database.InvGroupsTable[item.GroupID].CategoryID == DBConstants.AncientRelicsCategoryID)))
-//                {
-//                    CreateBlueprint(item, blueprints);
-//                }
+                // Add the items in this group
+                List<SerializableBlueprint> blueprints = new List<SerializableBlueprint>();
+                foreach (InvTypes item in Database.InvTypesTable.Where(
+                    item => item.MarketGroupID.GetValueOrDefault() == marketGroup.ID &&
+                            (Database.InvGroupsTable[item.GroupID].CategoryID == DBConstants.BlueprintCategoryID ||
+                             Database.InvGroupsTable[item.GroupID].CategoryID == DBConstants.AncientRelicsCategoryID)))
+                {
+                    CreateBlueprint(item, blueprints);
+                }
 
-//                // Store the items
-//                group.Blueprints.AddRange(blueprints.OrderBy(x => x.Name));
-//            }
-//        }
+                // Store the items
+                group.Blueprints.AddRange(blueprints.OrderBy(x => x.Name));
+            }
+        }
 
-//        /// <summary>
-//        /// Configures the null market blueprint.
-//        /// </summary>
-//        private static void ConfigureNullMarketBlueprint()
-//        {
-//            // Create custom market groups that don't exist in EVE
-//            s_injectedMarketGroups = new List<InvMarketGroups>
-//            {
-//                new InvMarketGroups
-//                {
-//                    Name = "Various Non-Market",
-//                    Description = "Various blueprints not in EVE market",
-//                    ID = DBConstants.BlueprintRootNonMarketGroupID,
-//                    ParentID = DBConstants.BlueprintsMarketGroupID,
-//                    IconID = DBConstants.UnknownBlueprintBackdropIconID
-//                },
-//                new InvMarketGroups
-//                {
-//                    Name = "Tech I",
-//                    Description = "Tech I blueprints not in EVE market",
-//                    ID = DBConstants.BlueprintTechINonMarketGroupID,
-//                    ParentID = DBConstants.BlueprintRootNonMarketGroupID,
-//                    IconID = DBConstants.UnknownBlueprintBackdropIconID
-//                },
-//                new InvMarketGroups
-//                {
-//                    Name = "Tech II",
-//                    Description = "Tech II blueprints not in EVE market",
-//                    ID = DBConstants.BlueprintTechIINonMarketGroupID,
-//                    ParentID = DBConstants.BlueprintRootNonMarketGroupID,
-//                    IconID = DBConstants.UnknownBlueprintBackdropIconID
-//                },
-//                new InvMarketGroups
-//                {
-//                    Name = "Storyline",
-//                    Description = "Storyline blueprints not in EVE market",
-//                    ID = DBConstants.BlueprintStorylineNonMarketGroupID,
-//                    ParentID = DBConstants.BlueprintRootNonMarketGroupID,
-//                    IconID = DBConstants.UnknownBlueprintBackdropIconID
-//                },
-//                new InvMarketGroups
-//                {
-//                    Name = "Faction",
-//                    Description = "Faction blueprints not in EVE market",
-//                    ID = DBConstants.BlueprintFactionNonMarketGroupID,
-//                    ParentID = DBConstants.BlueprintRootNonMarketGroupID,
-//                    IconID = DBConstants.UnknownBlueprintBackdropIconID
-//                },
-//                new InvMarketGroups
-//                {
-//                    Name = "Officer",
-//                    Description = "Officer blueprints not in EVE market",
-//                    ID = DBConstants.BlueprintOfficerNonMarketGroupID,
-//                    ParentID = DBConstants.BlueprintRootNonMarketGroupID,
-//                    IconID = DBConstants.UnknownBlueprintBackdropIconID
-//                },
-//                new InvMarketGroups
-//                {
-//                    Name = "Tech III",
-//                    Description = "Tech III blueprints not in EVE market",
-//                    ID = DBConstants.BlueprintTechIIINonMarketGroupID,
-//                    ParentID = DBConstants.BlueprintRootNonMarketGroupID,
-//                    IconID = DBConstants.UnknownBlueprintBackdropIconID
-//                },
-//                new InvMarketGroups
-//                {
-//                    Name = "Research Equipment",
-//                    Description = "Items that can be invented to a Tech III blueprint not in EVE market",
-//                    ID = DBConstants.ResearchEquipmentNonMarketGroupID,
-//                    ParentID = DBConstants.BlueprintRootNonMarketGroupID,
-//                    IconID = DBConstants.UnknownBlueprintBackdropIconID
-//                }
-//            };
+        /// <summary>
+        /// Configures the null market blueprint.
+        /// </summary>
+        private static void ConfigureNullMarketBlueprint()
+        {
+            // Create custom market groups that don't exist in EVE
+            s_injectedMarketGroups = new List<InvMarketGroups>
+            {
+                new InvMarketGroups
+                {
+                    Name = "Various Non-Market",
+                    Description = "Various blueprints not in EVE market",
+                    ID = DBConstants.BlueprintRootNonMarketGroupID,
+                    ParentID = DBConstants.BlueprintsMarketGroupID,
+                    IconID = DBConstants.UnknownBlueprintBackdropIconID
+                },
+                new InvMarketGroups
+                {
+                    Name = "Tech I",
+                    Description = "Tech I blueprints not in EVE market",
+                    ID = DBConstants.BlueprintTechINonMarketGroupID,
+                    ParentID = DBConstants.BlueprintRootNonMarketGroupID,
+                    IconID = DBConstants.UnknownBlueprintBackdropIconID
+                },
+                new InvMarketGroups
+                {
+                    Name = "Tech II",
+                    Description = "Tech II blueprints not in EVE market",
+                    ID = DBConstants.BlueprintTechIINonMarketGroupID,
+                    ParentID = DBConstants.BlueprintRootNonMarketGroupID,
+                    IconID = DBConstants.UnknownBlueprintBackdropIconID
+                },
+                new InvMarketGroups
+                {
+                    Name = "Storyline",
+                    Description = "Storyline blueprints not in EVE market",
+                    ID = DBConstants.BlueprintStorylineNonMarketGroupID,
+                    ParentID = DBConstants.BlueprintRootNonMarketGroupID,
+                    IconID = DBConstants.UnknownBlueprintBackdropIconID
+                },
+                new InvMarketGroups
+                {
+                    Name = "Faction",
+                    Description = "Faction blueprints not in EVE market",
+                    ID = DBConstants.BlueprintFactionNonMarketGroupID,
+                    ParentID = DBConstants.BlueprintRootNonMarketGroupID,
+                    IconID = DBConstants.UnknownBlueprintBackdropIconID
+                },
+                new InvMarketGroups
+                {
+                    Name = "Officer",
+                    Description = "Officer blueprints not in EVE market",
+                    ID = DBConstants.BlueprintOfficerNonMarketGroupID,
+                    ParentID = DBConstants.BlueprintRootNonMarketGroupID,
+                    IconID = DBConstants.UnknownBlueprintBackdropIconID
+                },
+                new InvMarketGroups
+                {
+                    Name = "Tech III",
+                    Description = "Tech III blueprints not in EVE market",
+                    ID = DBConstants.BlueprintTechIIINonMarketGroupID,
+                    ParentID = DBConstants.BlueprintRootNonMarketGroupID,
+                    IconID = DBConstants.UnknownBlueprintBackdropIconID
+                },
+                new InvMarketGroups
+                {
+                    Name = "Research Equipment",
+                    Description = "Items that can be invented to a Tech III blueprint not in EVE market",
+                    ID = DBConstants.ResearchEquipmentNonMarketGroupID,
+                    ParentID = DBConstants.BlueprintRootNonMarketGroupID,
+                    IconID = DBConstants.UnknownBlueprintBackdropIconID
+                }
+            };
 
-//            s_nullMarketBlueprints = Database.InvTypesTable
-//                .Where(item => item.MarketGroupID == null &&
-//                               Database.InvGroupsTable[item.GroupID].CategoryID == DBConstants.BlueprintCategoryID).ToList();
+            s_nullMarketBlueprints = Database.InvTypesTable
+                .Where(item => item.MarketGroupID == null &&
+                               Database.InvGroupsTable[item.GroupID].CategoryID == DBConstants.BlueprintCategoryID).ToList();
 
-//            // Set ancient relics to research equipment custom market group
-//            Database.InvTypesTable
-//                .Where(item => Database.InvGroupsTable[item.GroupID].CategoryID == DBConstants.AncientRelicsCategoryID)
-//                .ToList()
-//                .ForEach(x => x.MarketGroupID = DBConstants.ResearchEquipmentNonMarketGroupID);
+            // Set ancient relics to research equipment custom market group
+            Database.InvTypesTable
+                .Where(item => Database.InvGroupsTable[item.GroupID].CategoryID == DBConstants.AncientRelicsCategoryID)
+                .ToList()
+                .ForEach(x => x.MarketGroupID = DBConstants.ResearchEquipmentNonMarketGroupID);
 
-//            // Set the market group of the blueprints with NULL MarketGroupID to custom market groups
-//            foreach (InvTypes item in s_nullMarketBlueprints)
-//            {
-//                // Set some blueprints to market groups manually
-//                SetMarketGroupManually(item);
+            // Set the market group of the blueprints with NULL MarketGroupID to custom market groups
+            foreach (InvTypes item in s_nullMarketBlueprints)
+            {
+                // Set some blueprints to market groups manually
+                SetMarketGroupManually(item);
 
-//                // Set some blueprints to custom market groups according to their metagroup
-//                SetMarketGroupFromMetaGroup(item);
+                // Set some blueprints to custom market groups according to their metagroup
+                SetMarketGroupFromMetaGroup(item);
 
-//                if (item.MarketGroupID == null)
-//                    item.MarketGroupID = DBConstants.BlueprintTechINonMarketGroupID;
-//            }
-//        }
+                if (item.MarketGroupID == null)
+                    item.MarketGroupID = DBConstants.BlueprintTechINonMarketGroupID;
+            }
+        }
 
-//        /// <summary>
-//        /// Sets the market group.
-//        /// </summary>
-//        /// <param name="item">The item.</param>
-//        private static void SetMarketGroupManually(InvTypes item)
-//        {
-//            switch (item.ID)
-//            {
-//                case DBConstants.WildMinerIBlueprintID:
-//                case DBConstants.AlphaDataAnalyzerIBlueprintID:
-//                case DBConstants.DaemonDataAnalyzerIBlueprintID:
-//                case DBConstants.CodexDataAnalyzerIBlueprintID:
-//                case DBConstants.CropGasCloudHarvesterBlueprintID:
-//                case DBConstants.Dual1000mmScoutIAcceleratorCannonBlueprintID:
-//                case DBConstants.HabitatMinerIBlueprintID:
-//                case DBConstants.LibramDataAnalyzerIBlueprintID:
-//                case DBConstants.LimosCitadelCruiseLauncherIBlueprintID:
-//                case DBConstants.MagpieMobileTractorUnitBlueprintID:
-//                case DBConstants.PackratMobileTractorUnitBlueprintID:
-//                case DBConstants.PlowGascloudHarvesterBlueprintID:
-//                case DBConstants.ShockLimosCitadelTorpedoBayIBlueprintID:
-//                case DBConstants.WetuMobileDepotBlueprintID:
-//                case DBConstants.YurtMobileDepotBlueprintID:
-//                    item.MarketGroupID = DBConstants.BlueprintStorylineNonMarketGroupID;
-//                    break;
+        /// <summary>
+        /// Sets the market group.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        private static void SetMarketGroupManually(InvTypes item)
+        {
+            switch (item.ID)
+            {
+                case DBConstants.WildMinerIBlueprintID:
+                case DBConstants.AlphaDataAnalyzerIBlueprintID:
+                case DBConstants.DaemonDataAnalyzerIBlueprintID:
+                case DBConstants.CodexDataAnalyzerIBlueprintID:
+                case DBConstants.CropGasCloudHarvesterBlueprintID:
+                case DBConstants.Dual1000mmScoutIAcceleratorCannonBlueprintID:
+                case DBConstants.HabitatMinerIBlueprintID:
+                case DBConstants.LibramDataAnalyzerIBlueprintID:
+                case DBConstants.LimosCitadelCruiseLauncherIBlueprintID:
+                case DBConstants.MagpieMobileTractorUnitBlueprintID:
+                case DBConstants.PackratMobileTractorUnitBlueprintID:
+                case DBConstants.PlowGascloudHarvesterBlueprintID:
+                case DBConstants.ShockLimosCitadelTorpedoBayIBlueprintID:
+                case DBConstants.WetuMobileDepotBlueprintID:
+                case DBConstants.YurtMobileDepotBlueprintID:
+                    item.MarketGroupID = DBConstants.BlueprintStorylineNonMarketGroupID;
+                    break;
 
-//                case DBConstants.AsteroBlueprintID:
-//                case DBConstants.BarghestBlueprintID:
-//                case DBConstants.CambionBlueprintID:
-//                case DBConstants.ChremoasBlueprintID:
-//                case DBConstants.EtanaBlueprintID:
-//                case DBConstants.GarmurBlueprintID:
-//                case DBConstants.MaliceBlueprintID:
-//                case DBConstants.MorachaBlueprintID:
-//                case DBConstants.NestorBlueprintID:
-//                case DBConstants.OrthrusBlueprintID:
-//                case DBConstants.PolicePursuitCometBlueprintID:
-//                case DBConstants.ScorpionIshukoneWatchBlueprintID:
-//                case DBConstants.ShadowBlueprintID:
-//                case DBConstants.StratiosBlueprintID:
-//                case DBConstants.StratiosEmergencyResponderBlueprintID:
-//                case DBConstants.UtuBlueprintID:
-//                case DBConstants.VangelBlueprintID:
-//                case DBConstants.WhiptailBlueprintID:
-//                case DBConstants.AdrestiaBlueprintID:
-//                case DBConstants.EchelonBlueprintID:
-//                case DBConstants.ImperialNavySlicerBlueprintID:
-//                case DBConstants.CaldariNavyHookbillBlueprintID:
-//                case DBConstants.FederationNavyCometBlueprintID:
-//                case DBConstants.RepublicFleetFiretailBlueprintID:
-//                case DBConstants.NightmareBlueprintID:
-//                case DBConstants.MacharielBlueprintID:
-//                case DBConstants.DramielBlueprintID:
-//                case DBConstants.CruorBlueprintID:
-//                case DBConstants.SuccubusBlueprintID:
-//                case DBConstants.DaredevilBlueprintID:
-//                case DBConstants.CynabalBlueprintID:
-//                case DBConstants.AshimmuBlueprintID:
-//                case DBConstants.PhantasmBlueprintID:
-//                case DBConstants.GorusShuttleBlueprintID:
-//                case DBConstants.GuristasShuttleBlueprintID:
-//                case DBConstants.GallenteMiningLaserBlueprintID:
-//                case DBConstants.InterbusShuttleBlueprintID:
-//                case DBConstants.FrekiBlueprintID:
-//                case DBConstants.MimirBlueprintID:
-//                    item.MarketGroupID = DBConstants.BlueprintFactionNonMarketGroupID;
-//                    break;
+                case DBConstants.AsteroBlueprintID:
+                case DBConstants.BarghestBlueprintID:
+                case DBConstants.CambionBlueprintID:
+                case DBConstants.ChremoasBlueprintID:
+                case DBConstants.EtanaBlueprintID:
+                case DBConstants.GarmurBlueprintID:
+                case DBConstants.MaliceBlueprintID:
+                case DBConstants.MorachaBlueprintID:
+                case DBConstants.NestorBlueprintID:
+                case DBConstants.OrthrusBlueprintID:
+                case DBConstants.PolicePursuitCometBlueprintID:
+                case DBConstants.ScorpionIshukoneWatchBlueprintID:
+                case DBConstants.ShadowBlueprintID:
+                case DBConstants.StratiosBlueprintID:
+                case DBConstants.StratiosEmergencyResponderBlueprintID:
+                case DBConstants.UtuBlueprintID:
+                case DBConstants.VangelBlueprintID:
+                case DBConstants.WhiptailBlueprintID:
+                case DBConstants.AdrestiaBlueprintID:
+                case DBConstants.EchelonBlueprintID:
+                case DBConstants.ImperialNavySlicerBlueprintID:
+                case DBConstants.CaldariNavyHookbillBlueprintID:
+                case DBConstants.FederationNavyCometBlueprintID:
+                case DBConstants.RepublicFleetFiretailBlueprintID:
+                case DBConstants.NightmareBlueprintID:
+                case DBConstants.MacharielBlueprintID:
+                case DBConstants.DramielBlueprintID:
+                case DBConstants.CruorBlueprintID:
+                case DBConstants.SuccubusBlueprintID:
+                case DBConstants.DaredevilBlueprintID:
+                case DBConstants.CynabalBlueprintID:
+                case DBConstants.AshimmuBlueprintID:
+                case DBConstants.PhantasmBlueprintID:
+                case DBConstants.GorusShuttleBlueprintID:
+                case DBConstants.GuristasShuttleBlueprintID:
+                case DBConstants.GallenteMiningLaserBlueprintID:
+                case DBConstants.InterbusShuttleBlueprintID:
+                case DBConstants.FrekiBlueprintID:
+                case DBConstants.MimirBlueprintID:
+                    item.MarketGroupID = DBConstants.BlueprintFactionNonMarketGroupID;
+                    break;
 
-//                case DBConstants.BladeBlueprintID:
-//                case DBConstants.BlazeLBlueprintID:
-//                case DBConstants.BlazeMBlueprintID:
-//                case DBConstants.BlazeSBlueprintID:
-//                case DBConstants.BoltLBlueprintID:
-//                case DBConstants.BoltMBlueprintID:
-//                case DBConstants.BoltSBlueprintID:
-//                case DBConstants.CapitalRemoteCapacitorTransmitterIIBlueprintID:
-//                case DBConstants.CapitalRemoteShieldBoosterIIBlueprintID:
-//                case DBConstants.ChameleonBlueprintID:
-//                case DBConstants.DaggerBlueprintID:
-//                case DBConstants.DesolationLBlueprintID:
-//                case DBConstants.DesolationMBlueprintID:
-//                case DBConstants.DesolationSBlueprintID:
-//                case DBConstants.DroneDamageRigIIBlueprintID:
-//                case DBConstants.ErinyeBlueprintID:
-//                case DBConstants.GathererBlueprintID:
-//                case DBConstants.HighGradeAscendancyAlphaBlueprintID:
-//                case DBConstants.HighGradeAscendancyBetaBlueprintID:
-//                case DBConstants.HighGradeAscendancyGammaBlueprintID:
-//                case DBConstants.HighGradeAscendancyDeltaBlueprintID:
-//                case DBConstants.HighGradeAscendancyEpsilonBlueprintID:
-//                case DBConstants.HighGradeAscendancyOmegaBlueprintID:
-//                case DBConstants.KisharBlueprintID:
-//                case DBConstants.LuxLBlueprintID:
-//                case DBConstants.LuxMBlueprintID:
-//                case DBConstants.LuxSBlueprintID:
-//                case DBConstants.MackinawOREDevelopmentEditionBlueprintID:
-//                case DBConstants.MediumEWDroneRangeAugmentorIIBlueprintID:
-//                case DBConstants.MidGradeAscenancyAlphaBlueprintID:
-//                case DBConstants.MidGradeAscenancyBetaBlueprintID:
-//                case DBConstants.MidGradeAscenancyGammaBlueprintID:
-//                case DBConstants.MidGradeAscenancyDeltaBlueprintID:
-//                case DBConstants.MidGradeAscenancyEpsilonBlueprintID:
-//                case DBConstants.MidGradeAscenancyOmegaBlueprintID:
-//                case DBConstants.MinerIIChinaBlueprintID:
-//                case DBConstants.MiningLaserOptimizationIIBlueprintID:
-//                case DBConstants.MiningLaserRangeIIBlueprintID:
-//                case DBConstants.ReconProbeLauncherIIBlueprintID:
-//                case DBConstants.ScanProbeLauncherIIBlueprintID:
-//                case DBConstants.ShieldTransporterRigIIBlueprintID:
-//                case DBConstants.ShockLBlueprintID:
-//                case DBConstants.ShockMBlueprintID:
-//                case DBConstants.ShockSBlueprintID:
-//                case DBConstants.SmallEWDroneRangeAugmentorIIBlueprintID:
-//                case DBConstants.StormLBlueprintID:
-//                case DBConstants.StormMBlueprintID:
-//                case DBConstants.StormSBlueprintID:
-//                case DBConstants.TalismanAlphaBlueprintID:
-//                    item.MarketGroupID = DBConstants.BlueprintTechIINonMarketGroupID;
-//                    break;
+                case DBConstants.BladeBlueprintID:
+                case DBConstants.BlazeLBlueprintID:
+                case DBConstants.BlazeMBlueprintID:
+                case DBConstants.BlazeSBlueprintID:
+                case DBConstants.BoltLBlueprintID:
+                case DBConstants.BoltMBlueprintID:
+                case DBConstants.BoltSBlueprintID:
+                case DBConstants.CapitalRemoteCapacitorTransmitterIIBlueprintID:
+                case DBConstants.CapitalRemoteShieldBoosterIIBlueprintID:
+                case DBConstants.ChameleonBlueprintID:
+                case DBConstants.DaggerBlueprintID:
+                case DBConstants.DesolationLBlueprintID:
+                case DBConstants.DesolationMBlueprintID:
+                case DBConstants.DesolationSBlueprintID:
+                case DBConstants.DroneDamageRigIIBlueprintID:
+                case DBConstants.ErinyeBlueprintID:
+                case DBConstants.GathererBlueprintID:
+                case DBConstants.HighGradeAscendancyAlphaBlueprintID:
+                case DBConstants.HighGradeAscendancyBetaBlueprintID:
+                case DBConstants.HighGradeAscendancyGammaBlueprintID:
+                case DBConstants.HighGradeAscendancyDeltaBlueprintID:
+                case DBConstants.HighGradeAscendancyEpsilonBlueprintID:
+                case DBConstants.HighGradeAscendancyOmegaBlueprintID:
+                case DBConstants.KisharBlueprintID:
+                case DBConstants.LuxLBlueprintID:
+                case DBConstants.LuxMBlueprintID:
+                case DBConstants.LuxSBlueprintID:
+                case DBConstants.MackinawOREDevelopmentEditionBlueprintID:
+                case DBConstants.MediumEWDroneRangeAugmentorIIBlueprintID:
+                case DBConstants.MidGradeAscenancyAlphaBlueprintID:
+                case DBConstants.MidGradeAscenancyBetaBlueprintID:
+                case DBConstants.MidGradeAscenancyGammaBlueprintID:
+                case DBConstants.MidGradeAscenancyDeltaBlueprintID:
+                case DBConstants.MidGradeAscenancyEpsilonBlueprintID:
+                case DBConstants.MidGradeAscenancyOmegaBlueprintID:
+                case DBConstants.MinerIIChinaBlueprintID:
+                case DBConstants.MiningLaserOptimizationIIBlueprintID:
+                case DBConstants.MiningLaserRangeIIBlueprintID:
+                case DBConstants.ReconProbeLauncherIIBlueprintID:
+                case DBConstants.ScanProbeLauncherIIBlueprintID:
+                case DBConstants.ShieldTransporterRigIIBlueprintID:
+                case DBConstants.ShockLBlueprintID:
+                case DBConstants.ShockMBlueprintID:
+                case DBConstants.ShockSBlueprintID:
+                case DBConstants.SmallEWDroneRangeAugmentorIIBlueprintID:
+                case DBConstants.StormLBlueprintID:
+                case DBConstants.StormMBlueprintID:
+                case DBConstants.StormSBlueprintID:
+                case DBConstants.TalismanAlphaBlueprintID:
+                    item.MarketGroupID = DBConstants.BlueprintTechIINonMarketGroupID;
+                    break;
 
-//                case DBConstants.LegionBlueprintID:
-//                case DBConstants.LegionDefensiveAdaptiveAugmenterBlueprintID:
-//                case DBConstants.LegionElectronicsEnergyParasiticComplexBlueprintID:
-//                case DBConstants.LegionEngineeringPowerCoreMultiplierBlueprintID:
-//                case DBConstants.LegionOffensiveDroneSynthesisProjectorBlueprintID:
-//                case DBConstants.LegionPropulsionChassisOptimizationBlueprintID:
-//                case DBConstants.LokiBlueprintID:
-//                case DBConstants.LokiDefensiveAdaptiveShieldingBlueprintID:
-//                case DBConstants.LokiElectronicsImmobilityDriversBlueprintID:
-//                case DBConstants.LokiEngineeringPowerCoreMultiplierBlueprintID:
-//                case DBConstants.LokiOffensiveTurretConcurrenceRegistryBlueprintID:
-//                case DBConstants.LokiPropulsionChassisOptimizationBlueprintID:
-//                case DBConstants.ProteusBlueprintID:
-//                case DBConstants.ProteusDefensiveAdaptiveAugmenterBlueprintID:
-//                case DBConstants.ProteusElectronicsFrictionExtensionProcessorBlueprintID:
-//                case DBConstants.ProteusEngineeringPowerCoreMultiplierBlueprintID:
-//                case DBConstants.ProteusOffensiveDissonicEncodingPlatformBlueprintID:
-//                case DBConstants.ProteusPropulsionWakeLimiterBlueprintID:
-//                case DBConstants.TenguBlueprintID:
-//                case DBConstants.TenguDefensiveAdaptiveShieldingBlueprintID:
-//                case DBConstants.TenguElectronicsObfuscationManifoldBlueprintID:
-//                case DBConstants.TenguEngineeringPowerCoreMultiplierBlueprintID:
-//                case DBConstants.TenguOffensiveAcceleratedEjectionBayBlueprintID:
-//                case DBConstants.TenguPropulsionIntercalatedNanofibersBlueprintID:
-//                    item.MarketGroupID = DBConstants.BlueprintTechIIINonMarketGroupID;
-//                    break;
-//            }
-//        }
+                case DBConstants.LegionBlueprintID:
+                case DBConstants.LegionDefensiveAdaptiveAugmenterBlueprintID:
+                case DBConstants.LegionElectronicsEnergyParasiticComplexBlueprintID:
+                case DBConstants.LegionEngineeringPowerCoreMultiplierBlueprintID:
+                case DBConstants.LegionOffensiveDroneSynthesisProjectorBlueprintID:
+                case DBConstants.LegionPropulsionChassisOptimizationBlueprintID:
+                case DBConstants.LokiBlueprintID:
+                case DBConstants.LokiDefensiveAdaptiveShieldingBlueprintID:
+                case DBConstants.LokiElectronicsImmobilityDriversBlueprintID:
+                case DBConstants.LokiEngineeringPowerCoreMultiplierBlueprintID:
+                case DBConstants.LokiOffensiveTurretConcurrenceRegistryBlueprintID:
+                case DBConstants.LokiPropulsionChassisOptimizationBlueprintID:
+                case DBConstants.ProteusBlueprintID:
+                case DBConstants.ProteusDefensiveAdaptiveAugmenterBlueprintID:
+                case DBConstants.ProteusElectronicsFrictionExtensionProcessorBlueprintID:
+                case DBConstants.ProteusEngineeringPowerCoreMultiplierBlueprintID:
+                case DBConstants.ProteusOffensiveDissonicEncodingPlatformBlueprintID:
+                case DBConstants.ProteusPropulsionWakeLimiterBlueprintID:
+                case DBConstants.TenguBlueprintID:
+                case DBConstants.TenguDefensiveAdaptiveShieldingBlueprintID:
+                case DBConstants.TenguElectronicsObfuscationManifoldBlueprintID:
+                case DBConstants.TenguEngineeringPowerCoreMultiplierBlueprintID:
+                case DBConstants.TenguOffensiveAcceleratedEjectionBayBlueprintID:
+                case DBConstants.TenguPropulsionIntercalatedNanofibersBlueprintID:
+                    item.MarketGroupID = DBConstants.BlueprintTechIIINonMarketGroupID;
+                    break;
+            }
+        }
 
-//        /// <summary>
-//        /// Sets the market group from meta group.
-//        /// </summary>
-//        /// <param name="item">The item.</param>
-//        private static void SetMarketGroupFromMetaGroup(InvTypes item)
-//        {
-//            // Guard in case an item of blueprint type is not contained in the blueprints table (glorious CCP)
-//            if (Database.InvBlueprintTypesTable.All(x => x.ID != item.ID))
-//                return;
+        /// <summary>
+        /// Sets the market group from meta group.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        private static void SetMarketGroupFromMetaGroup(InvTypes item)
+        {
+            // Guard in case an item of blueprint type is not contained in the blueprints table (glorious CCP)
+            if (Database.InvBlueprintTypesTable.All(x => x.ID != item.ID))
+                return;
 
-//            int relation = Database.InvMetaTypesTable.Where(
-//                x => x.ItemID == Database.InvBlueprintTypesTable[item.ID].ProductTypeID).Select(
-//                    x => x.MetaGroupID).FirstOrDefault();
+            int relation = Database.InvMetaTypesTable.Where(
+                x => x.ItemID == Database.InvBlueprintTypesTable[item.ID].ProductTypeID).Select(
+                    x => x.MetaGroupID).FirstOrDefault();
 
-//            switch (relation)
-//            {
-//                case DBConstants.TechIIMetaGroupID:
-//                    item.MarketGroupID = DBConstants.BlueprintTechIINonMarketGroupID;
-//                    break;
-//                case DBConstants.StorylineMetaGroupID:
-//                    item.MarketGroupID = DBConstants.BlueprintStorylineNonMarketGroupID;
-//                    break;
-//                case DBConstants.FactionMetaGroupID:
-//                    item.MarketGroupID = DBConstants.BlueprintFactionNonMarketGroupID;
-//                    break;
-//                case DBConstants.OfficerMetaGroupID:
-//                    item.MarketGroupID = DBConstants.BlueprintOfficerNonMarketGroupID;
-//                    break;
-//                case DBConstants.TechIIIMetaGroupID:
-//                    item.MarketGroupID = DBConstants.BlueprintTechIIINonMarketGroupID;
-//                    break;
-//            }
-//        }
+            switch (relation)
+            {
+                case DBConstants.TechIIMetaGroupID:
+                    item.MarketGroupID = DBConstants.BlueprintTechIINonMarketGroupID;
+                    break;
+                case DBConstants.StorylineMetaGroupID:
+                    item.MarketGroupID = DBConstants.BlueprintStorylineNonMarketGroupID;
+                    break;
+                case DBConstants.FactionMetaGroupID:
+                    item.MarketGroupID = DBConstants.BlueprintFactionNonMarketGroupID;
+                    break;
+                case DBConstants.OfficerMetaGroupID:
+                    item.MarketGroupID = DBConstants.BlueprintOfficerNonMarketGroupID;
+                    break;
+                case DBConstants.TechIIIMetaGroupID:
+                    item.MarketGroupID = DBConstants.BlueprintTechIIINonMarketGroupID;
+                    break;
+            }
+        }
 
-//        /// <summary>
-//        /// Add properties to a blueprint.
-//        /// </summary>
-//        /// <param name="srcBlueprint"></param>
-//        /// <param name="blueprintsGroup"></param>
-//        /// <returns></returns>
-//        private static void CreateBlueprint(InvTypes srcBlueprint, ICollection<SerializableBlueprint> blueprintsGroup)
-//        {
-//            Util.UpdatePercentDone(Database.BlueprintsTotalCount);
+        /// <summary>
+        /// Add properties to a blueprint.
+        /// </summary>
+        /// <param name="srcBlueprint"></param>
+        /// <param name="blueprintsGroup"></param>
+        /// <returns></returns>
+        private static void CreateBlueprint(InvTypes srcBlueprint, ICollection<SerializableBlueprint> blueprintsGroup)
+        {
+            Util.UpdatePercentDone(Database.BlueprintsTotalCount);
 
-//            // Guard in case an item of blueprint type is not contained in the blueprints table (glorious CCP)
-//            if (Database.InvBlueprintTypesTable.All(x => x.ID != srcBlueprint.ID))
-//                return;
+            // Guard in case an item of blueprint type is not contained in the blueprints table (glorious CCP)
+            if (Database.InvBlueprintTypesTable.All(x => x.ID != srcBlueprint.ID))
+                return;
 
-//            InvBlueprintTypes blueprintType = Database.InvBlueprintTypesTable[srcBlueprint.ID];
+            InvBlueprintTypes blueprintType = Database.InvBlueprintTypesTable[srcBlueprint.ID];
 
-//            // Creates the blueprint with base informations
-//            SerializableBlueprint blueprint = new SerializableBlueprint
-//            {
-//                ID = srcBlueprint.ID,
-//                Name = srcBlueprint.Name,
-//                Icon = srcBlueprint.IconID.HasValue
-//                    ? Database.EveIconsTable[srcBlueprint.IconID.Value].Icon
-//                    : String.Empty,
-//                ProduceItemID = blueprintType.ProductTypeID,
-//                ProductionTime = blueprintType.ProductionTime,
-//                ResearchProductivityTime = blueprintType.ResearchProductivityTime,
-//                ResearchMaterialTime = blueprintType.ResearchMaterialTime,
-//                ResearchCopyTime = blueprintType.ResearchCopyTime,
-//                InventionTime = blueprintType.InventionTime,
-//                ReverseEngineeringTime = blueprintType.ReverseEngineeringTime,
-//                MaxProductionLimit = blueprintType.MaxProductionLimit,
-//            };
+            // Creates the blueprint with base informations
+            SerializableBlueprint blueprint = new SerializableBlueprint
+            {
+                ID = srcBlueprint.ID,
+                Name = srcBlueprint.Name,
+                Icon = srcBlueprint.IconID.HasValue
+                    ? Database.EveIconsTable[srcBlueprint.IconID.Value].Icon
+                    : String.Empty,
+                ProduceItemID = blueprintType.ProductTypeID,
+                ProductionTime = blueprintType.ProductionTime,
+                ResearchProductivityTime = blueprintType.ResearchProductivityTime,
+                ResearchMaterialTime = blueprintType.ResearchMaterialTime,
+                ResearchCopyTime = blueprintType.ResearchCopyTime,
+                InventionTime = blueprintType.InventionTime,
+                ReverseEngineeringTime = blueprintType.ReverseEngineeringTime,
+                MaxProductionLimit = blueprintType.MaxProductionLimit,
+            };
 
-//            // Metagroup
-//            SetBlueprintMetaGroup(srcBlueprint, blueprint);
+            // Metagroup
+            SetBlueprintMetaGroup(srcBlueprint, blueprint);
 
-//            // Export item requirements
-//            GetRequirements(srcBlueprint, blueprint);
+            // Export item requirements
+            GetRequirements(srcBlueprint, blueprint);
 
-//            // Look for the tech 2 or tech 3 variations that this blueprint invents
-//            GetInventingItems(srcBlueprint, blueprint);
+            // Look for the tech 2 or tech 3 variations that this blueprint invents
+            GetInventingItems(srcBlueprint, blueprint);
 
-//            // Add this item
-//            blueprintsGroup.Add(blueprint);
-//        }
+            // Add this item
+            blueprintsGroup.Add(blueprint);
+        }
 
-//        /// <summary>
-//        /// Gets the inventing items.
-//        /// </summary>
-//        /// <param name="srcBlueprint">The source blueprint.</param>
-//        /// <param name="blueprint">The blueprint.</param>
-//        private static void GetInventingItems(InvTypes srcBlueprint, SerializableBlueprint blueprint)
-//        {
-//            foreach (RamTypeRequirements requirement in Database.RamTypeRequirementsTable
-//                .Where(requirement => requirement.ID == srcBlueprint.ID &&
-//                                      Database.InvBlueprintTypesTable.Any(x => x.ID == requirement.RequiredTypeID) &&
-//                                      (requirement.ActivityID == (int)BlueprintActivity.Invention ||
-//                                       requirement.ActivityID == (int)BlueprintActivity.ReverseEngineering)))
-//            {
-//                blueprint.InventionTypeIDs.Add(requirement.RequiredTypeID, requirement.Probability.GetValueOrDefault());
-//            }
-//        }
+        /// <summary>
+        /// Gets the inventing items.
+        /// </summary>
+        /// <param name="srcBlueprint">The source blueprint.</param>
+        /// <param name="blueprint">The blueprint.</param>
+        private static void GetInventingItems(InvTypes srcBlueprint, SerializableBlueprint blueprint)
+        {
+            foreach (RamTypeRequirements requirement in Database.RamTypeRequirementsTable
+                .Where(requirement => requirement.ID == srcBlueprint.ID &&
+                                      Database.InvBlueprintTypesTable.Any(x => x.ID == requirement.RequiredTypeID) &&
+                                      (requirement.ActivityID == (int)BlueprintActivity.Invention ||
+                                       requirement.ActivityID == (int)BlueprintActivity.ReverseEngineering)))
+            {
+                blueprint.InventionTypeIDs.Add(requirement.RequiredTypeID, requirement.Probability.GetValueOrDefault());
+            }
+        }
 
-//        /// <summary>
-//        /// Sets the blueprint meta group.
-//        /// </summary>
-//        /// <param name="srcBlueprint">The SRC blueprint.</param>
-//        /// <param name="blueprint">The blueprint.</param>
-//        private static void SetBlueprintMetaGroup(InvTypes srcBlueprint, SerializableBlueprint blueprint)
-//        {
-//            foreach (InvMetaTypes relation in Database.InvMetaTypesTable.Where(
-//                x => x.ItemID == Database.InvBlueprintTypesTable[srcBlueprint.ID].ProductTypeID))
-//            {
-//                switch (relation.MetaGroupID)
-//                {
-//                    default:
-//                        blueprint.MetaGroup = ItemMetaGroup.T1;
-//                        break;
-//                    case DBConstants.TechIIMetaGroupID:
-//                        blueprint.MetaGroup = ItemMetaGroup.T2;
-//                        break;
-//                    case DBConstants.StorylineMetaGroupID:
-//                        blueprint.MetaGroup = ItemMetaGroup.Storyline;
-//                        break;
-//                    case DBConstants.FactionMetaGroupID:
-//                        blueprint.MetaGroup = ItemMetaGroup.Faction;
-//                        break;
-//                    case DBConstants.OfficerMetaGroupID:
-//                        blueprint.MetaGroup = ItemMetaGroup.Officer;
-//                        break;
-//                    case DBConstants.DeadspaceMetaGroupID:
-//                        blueprint.MetaGroup = ItemMetaGroup.Deadspace;
-//                        break;
-//                    case DBConstants.TechIIIMetaGroupID:
-//                        blueprint.MetaGroup = ItemMetaGroup.T3;
-//                        break;
-//                }
-//            }
+        /// <summary>
+        /// Sets the blueprint meta group.
+        /// </summary>
+        /// <param name="srcBlueprint">The SRC blueprint.</param>
+        /// <param name="blueprint">The blueprint.</param>
+        private static void SetBlueprintMetaGroup(InvTypes srcBlueprint, SerializableBlueprint blueprint)
+        {
+            foreach (InvMetaTypes relation in Database.InvMetaTypesTable.Where(
+                x => x.ItemID == Database.InvBlueprintTypesTable[srcBlueprint.ID].ProductTypeID))
+            {
+                switch (relation.MetaGroupID)
+                {
+                    default:
+                        blueprint.MetaGroup = ItemMetaGroup.T1;
+                        break;
+                    case DBConstants.TechIIMetaGroupID:
+                        blueprint.MetaGroup = ItemMetaGroup.T2;
+                        break;
+                    case DBConstants.StorylineMetaGroupID:
+                        blueprint.MetaGroup = ItemMetaGroup.Storyline;
+                        break;
+                    case DBConstants.FactionMetaGroupID:
+                        blueprint.MetaGroup = ItemMetaGroup.Faction;
+                        break;
+                    case DBConstants.OfficerMetaGroupID:
+                        blueprint.MetaGroup = ItemMetaGroup.Officer;
+                        break;
+                    case DBConstants.DeadspaceMetaGroupID:
+                        blueprint.MetaGroup = ItemMetaGroup.Deadspace;
+                        break;
+                    case DBConstants.TechIIIMetaGroupID:
+                        blueprint.MetaGroup = ItemMetaGroup.T3;
+                        break;
+                }
+            }
 
-//            // Metagroup for the custom market groups
-//            switch (srcBlueprint.MarketGroupID)
-//            {
-//                case DBConstants.BlueprintStorylineNonMarketGroupID:
-//                    blueprint.MetaGroup = ItemMetaGroup.Storyline;
-//                    break;
-//                case DBConstants.BlueprintFactionNonMarketGroupID:
-//                    blueprint.MetaGroup = ItemMetaGroup.Faction;
-//                    break;
-//                case DBConstants.BlueprintOfficerNonMarketGroupID:
-//                    blueprint.MetaGroup = ItemMetaGroup.Officer;
-//                    break;
-//                case DBConstants.BlueprintTechIIINonMarketGroupID:
-//                    blueprint.MetaGroup = ItemMetaGroup.T3;
-//                    break;
-//                case DBConstants.BlueprintTechIINonMarketGroupID:
-//                    blueprint.MetaGroup = ItemMetaGroup.T2;
-//                    break;
-//            }
+            // Metagroup for the custom market groups
+            switch (srcBlueprint.MarketGroupID)
+            {
+                case DBConstants.BlueprintStorylineNonMarketGroupID:
+                    blueprint.MetaGroup = ItemMetaGroup.Storyline;
+                    break;
+                case DBConstants.BlueprintFactionNonMarketGroupID:
+                    blueprint.MetaGroup = ItemMetaGroup.Faction;
+                    break;
+                case DBConstants.BlueprintOfficerNonMarketGroupID:
+                    blueprint.MetaGroup = ItemMetaGroup.Officer;
+                    break;
+                case DBConstants.BlueprintTechIIINonMarketGroupID:
+                    blueprint.MetaGroup = ItemMetaGroup.T3;
+                    break;
+                case DBConstants.BlueprintTechIINonMarketGroupID:
+                    blueprint.MetaGroup = ItemMetaGroup.T2;
+                    break;
+            }
 
-//            if (blueprint.MetaGroup == ItemMetaGroup.None)
-//                blueprint.MetaGroup = ItemMetaGroup.T1;
-//        }
+            if (blueprint.MetaGroup == ItemMetaGroup.None)
+                blueprint.MetaGroup = ItemMetaGroup.T1;
+        }
 
-//        /// <summary>
-//        /// Get's the item requirements. 
-//        /// </summary>
-//        /// <param name="srcBlueprint"></param>
-//        /// <param name="blueprint"></param>
-//        private static void GetRequirements(IHasID srcBlueprint, SerializableBlueprint blueprint)
-//        {
-//            List<SerializablePrereqSkill> prerequisiteSkills = new List<SerializablePrereqSkill>();
-//            List<SerializableRequiredMaterial> requiredMaterials = new List<SerializableRequiredMaterial>();
+        /// <summary>
+        /// Get's the item requirements. 
+        /// </summary>
+        /// <param name="srcBlueprint"></param>
+        /// <param name="blueprint"></param>
+        private static void GetRequirements(IHasID srcBlueprint, SerializableBlueprint blueprint)
+        {
+            List<SerializablePrereqSkill> prerequisiteSkills = new List<SerializablePrereqSkill>();
+            List<SerializableRequiredMaterial> requiredMaterials = new List<SerializableRequiredMaterial>();
 
-//            // Find the requirements and add them to the list, ignore any blueprint type
-//            foreach (RamTypeRequirements requirement in Database.RamTypeRequirementsTable
-//                .Where(requirement => requirement.ID == srcBlueprint.ID &&
-//                                      Database.InvBlueprintTypesTable.All(x => x.ID != requirement.RequiredTypeID)))
-//            {
-//                // Is it a skill ? Add it to the prerequisities skills list
-//                if (requirement.Level.HasValue)
-//                {
-//                    prerequisiteSkills.Add(new SerializablePrereqSkill
-//                    {
-//                        ID = requirement.RequiredTypeID,
-//                        Level = requirement.Level.Value,
-//                        Activity = requirement.ActivityID
-//                    });
-//                    continue;
-//                }
+            // Find the requirements and add them to the list, ignore any blueprint type
+            foreach (RamTypeRequirements requirement in Database.RamTypeRequirementsTable
+                .Where(requirement => requirement.ID == srcBlueprint.ID &&
+                                      Database.InvBlueprintTypesTable.All(x => x.ID != requirement.RequiredTypeID)))
+            {
+                // Is it a skill ? Add it to the prerequisities skills list
+                if (requirement.Level.HasValue)
+                {
+                    prerequisiteSkills.Add(new SerializablePrereqSkill
+                    {
+                        ID = requirement.RequiredTypeID,
+                        Level = requirement.Level.Value,
+                        Activity = requirement.ActivityID
+                    });
+                    continue;
+                }
 
-//                // It is an item (material)
-//                if (requirement.Quantity.HasValue)
-//                {
-//                    requiredMaterials.Add(new SerializableRequiredMaterial
-//                    {
-//                        ID = requirement.RequiredTypeID,
-//                        Quantity = requirement.Quantity.Value,
-//                        Activity = requirement.ActivityID,
-//                    });
-//                }
-//            }
+                // It is an item (material)
+                if (requirement.Quantity.HasValue)
+                {
+                    requiredMaterials.Add(new SerializableRequiredMaterial
+                    {
+                        ID = requirement.RequiredTypeID,
+                        Quantity = requirement.Quantity.Value,
+                        Activity = requirement.ActivityID,
+                    });
+                }
+            }
 
-//            // Add prerequisite skills to item
-//            blueprint.PrereqSkill.AddRange(prerequisiteSkills.OrderBy(x => x.Activity));
+            // Add prerequisite skills to item
+            blueprint.PrereqSkill.AddRange(prerequisiteSkills.OrderBy(x => x.Activity));
 
-//            // Add required materials to item
-//            blueprint.ReqMaterial.AddRange(requiredMaterials.OrderBy(x => x.Activity));
-//        }
-//    }
-//}
+            // Add required materials to item
+            blueprint.ReqMaterial.AddRange(requiredMaterials.OrderBy(x => x.Activity));
+        }
+    }
+}

--- a/tools/XmlGenerator/Datafiles/Blueprints.cs
+++ b/tools/XmlGenerator/Datafiles/Blueprints.cs
@@ -450,7 +450,7 @@ namespace EVEMon.XmlGenerator.Datafiles
                                       (requirement.ActivityID == (int)BlueprintActivity.Invention ||
                                        requirement.ActivityID == (int)BlueprintActivity.ReverseEngineering)))
             {
-                blueprint.InventionTypeIDs.Add(requirement.RequiredTypeID, requirement.Probability.GetValueOrDefault());
+                blueprint.InventionTypeIDs.Add(requirement.RequiredTypeID, (decimal)requirement.Probability.GetValueOrDefault());
             }
         }
 

--- a/tools/XmlGenerator/Models/invBlueprintTypes.cs
+++ b/tools/XmlGenerator/Models/invBlueprintTypes.cs
@@ -12,13 +12,13 @@ namespace EVEMon.XmlGenerator.Models
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int blueprintTypeID { get; set; }
 
-        public int? parentBlueprintTypeID { get; set; }
+        //public int? parentBlueprintTypeID { get; set; }
 
         public int? productTypeID { get; set; }
 
         public int? productionTime { get; set; }
 
-        public short? techLevel { get; set; }
+        //public short? techLevel { get; set; }
 
         public int? researchProductivityTime { get; set; }
 
@@ -26,19 +26,19 @@ namespace EVEMon.XmlGenerator.Models
 
         public int? researchCopyTime { get; set; }
 
-        public int? researchTechTime { get; set; }
+        //public int? researchTechTime { get; set; }
 
-        public int? duplicatingTime { get; set; }
+        //public int? duplicatingTime { get; set; }
 
         public int? reverseEngineeringTime { get; set; }
 
         public int? inventionTime { get; set; }
 
-        public int? productivityModifier { get; set; }
+        //public int? productivityModifier { get; set; }
 
-        public short? materialModifier { get; set; }
+        //public short? materialModifier { get; set; }
 
-        public short? wasteFactor { get; set; }
+        //public short? wasteFactor { get; set; }
 
         public int? maxProductionLimit { get; set; }
     }

--- a/tools/XmlGenerator/Models/invBlueprintTypes.cs
+++ b/tools/XmlGenerator/Models/invBlueprintTypes.cs
@@ -12,13 +12,9 @@ namespace EVEMon.XmlGenerator.Models
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int blueprintTypeID { get; set; }
 
-        //public int? parentBlueprintTypeID { get; set; }
-
         public int? productTypeID { get; set; }
 
         public int? productionTime { get; set; }
-
-        //public short? techLevel { get; set; }
 
         public int? researchProductivityTime { get; set; }
 
@@ -26,19 +22,9 @@ namespace EVEMon.XmlGenerator.Models
 
         public int? researchCopyTime { get; set; }
 
-        //public int? researchTechTime { get; set; }
-
-        //public int? duplicatingTime { get; set; }
-
         public int? reverseEngineeringTime { get; set; }
 
         public int? inventionTime { get; set; }
-
-        //public int? productivityModifier { get; set; }
-
-        //public short? materialModifier { get; set; }
-
-        //public short? wasteFactor { get; set; }
 
         public int? maxProductionLimit { get; set; }
     }

--- a/tools/XmlGenerator/Models/ramTypeRequirements.cs
+++ b/tools/XmlGenerator/Models/ramTypeRequirements.cs
@@ -26,14 +26,14 @@ namespace EVEMon.XmlGenerator.Models
 
         public int? level { get; set; }
 
-        public double? damagePerJob { get; set; }
+        //public double? damagePerJob { get; set; }
 
-        public bool? recycle { get; set; }
+        //public bool? recycle { get; set; }
 
-        public int? raceID { get; set; }
+        //public int? raceID { get; set; }
 
         public double? probability { get; set; }
 
-        public bool? consume { get; set; }
+        //public bool? consume { get; set; }
     }
 }

--- a/tools/XmlGenerator/Models/ramTypeRequirements.cs
+++ b/tools/XmlGenerator/Models/ramTypeRequirements.cs
@@ -26,14 +26,6 @@ namespace EVEMon.XmlGenerator.Models
 
         public int? level { get; set; }
 
-        //public double? damagePerJob { get; set; }
-
-        //public bool? recycle { get; set; }
-
-        //public int? raceID { get; set; }
-
         public double? probability { get; set; }
-
-        //public bool? consume { get; set; }
     }
 }

--- a/tools/XmlGenerator/Program.cs
+++ b/tools/XmlGenerator/Program.cs
@@ -35,7 +35,7 @@ namespace EVEMon.XmlGenerator
             //Masteries.GenerateDatafile();
 
             Geography.GenerateDatafile();
-			//Blueprints.GenerateDatafile();
+			Blueprints.GenerateDatafile();
 			Items.GenerateDatafile(); // Requires GenerateProperties()
             Reprocessing.GenerateDatafile(); // Requires GenerateItems()
 

--- a/tools/XmlGenerator/Providers/Database.cs
+++ b/tools/XmlGenerator/Providers/Database.cs
@@ -41,6 +41,38 @@ from invTypes it
 	left join industryActivity ia7 on ia7.typeID = it.typeID and ia7.activityID = 7
 	left join industryActivity ia8 on ia8.typeID = it.typeID and ia8.activityID = 8";
 
+        private const string ramTypeRequirementsQuery = @"
+select 	2 as sort,
+		ia.typeID,
+		ia.activityID,
+		iam.materialTypeID as requiredTypeID,
+		iam.quantity,
+		null as level,
+		null as probability
+from industryActivity ia
+	inner join industryActivityMaterials iam on ia.typeID = iam.typeID and ia.activityID = iam.activityID
+union all
+select 	1 as sort,
+		ia.typeID,
+		ia.activityID,
+		ias.skillID as requiredTypeID,
+		null as quantity,
+		ias.level,
+		null as probability
+from industryActivity ia
+	inner join industryActivitySkills ias on ia.typeID = ias.typeID and ia.activityID = ias.activityID
+union all
+select 	0 as sort,
+		ia.typeID,
+		ia.activityID,
+		iap.productTypeID as requiredTypeID,
+		null as quantity,
+		null as level,
+		iap.probability
+from industryActivity ia
+	inner join industryActivityProbabilities iap on ia.typeID = iap.typeID and ia.activityID = iap.activityID
+order by 1,2,3,4";
+
         #region Properties
 
         /// <summary>
@@ -431,9 +463,9 @@ from invTypes it
             MapSolarSystemsTable = SolarSystems();
             Util.UpdateProgress(s_totalTablesCount);
 
-			// Figure out what this used to be and what it became. Do we even need to worry about Industry right now?
-            //RamTypeRequirementsTable = TypeRequirements();
-            //Util.UpdateProgress(s_totalTablesCount);
+            // Figure out what this used to be and what it became. Do we even need to worry about Industry right now?
+            RamTypeRequirementsTable = TypeRequirements();
+            Util.UpdateProgress(s_totalTablesCount);
 
             StaStationsTable = Stations();
             Util.UpdateProgress(s_totalTablesCount);
@@ -1264,7 +1296,7 @@ from invTypes it
         {
             List<RamTypeRequirements> list = new List<RamTypeRequirements>();
 
-            foreach (ramTypeRequirements requirement in s_context.ramTypeRequirements)
+            foreach (ramTypeRequirements requirement in s_context.ramTypeRequirements.SqlQuery(ramTypeRequirementsQuery))
             {
                 RamTypeRequirements item = new RamTypeRequirements
                 {
@@ -1279,20 +1311,20 @@ from invTypes it
                 if (requirement.level.HasValue)
                     item.Level = requirement.level.Value;
 
-                if (requirement.damagePerJob.HasValue)
-                    item.DamagePerJob = requirement.damagePerJob.Value;
+                //if (requirement.damagePerJob.HasValue)
+                //    item.DamagePerJob = requirement.damagePerJob.Value;
 
-                if (requirement.recycle.HasValue)
-                    item.Recyclable = requirement.recycle.Value;
+                //if (requirement.recycle.HasValue)
+                //    item.Recyclable = requirement.recycle.Value;
 
-                if (requirement.raceID.HasValue)
-                    item.RaceID = requirement.raceID.Value;
+                //if (requirement.raceID.HasValue)
+                //    item.RaceID = requirement.raceID.Value;
 
                 if (requirement.probability.HasValue)
                     item.Probability = requirement.probability.Value;
 
-                if (requirement.consume.HasValue)
-                    item.Consume = requirement.consume.Value;
+                //if (requirement.consume.HasValue)
+                //    item.Consume = requirement.consume.Value;
 
                 list.Add(item);
             }

--- a/tools/XmlGenerator/Providers/Database.cs
+++ b/tools/XmlGenerator/Providers/Database.cs
@@ -197,8 +197,6 @@ order by 1,2,3,4";
         /// <value>The eve units table.</value>
         internal static BagCollection<EveUnits> EveUnitsTable { get; private set; }
 
-        //internal static BagCollection<IndustryBlueprints> IndustryBlueprintsTable { get; private set; }
-
         /// <summary>
         /// Gets or sets the inv items table.
         /// </summary>
@@ -416,8 +414,8 @@ order by 1,2,3,4";
             DgmTypeEffectsTable = TypeEffects();
             Util.UpdateProgress(s_totalTablesCount);
 
-			// Find out what this used to be and find a way around it... Is it even useful?
-			//DgmTypeTraitsTable = TypeTraits();
+            // Find out what this used to be and find a way around it... Is it even useful?
+            //DgmTypeTraitsTable = TypeTraits();
             //Util.UpdateProgress(s_totalTablesCount);
 
             EveIconsTable = Icons();
@@ -425,9 +423,7 @@ order by 1,2,3,4";
             EveUnitsTable = Units();
             Util.UpdateProgress(s_totalTablesCount);
 
-            // Find out what this used to be and find a way around it... Be interesting to see
-            // if BPs apepar in the new invItems table and their traits in invTraits
-			InvBlueprintTypesTable = BlueprintTypes();
+            InvBlueprintTypesTable = BlueprintTypes();
             Util.UpdateProgress(s_totalTablesCount);
 
             InvCategoriesTable = Categories();
@@ -463,7 +459,6 @@ order by 1,2,3,4";
             MapSolarSystemsTable = SolarSystems();
             Util.UpdateProgress(s_totalTablesCount);
 
-            // Figure out what this used to be and what it became. Do we even need to worry about Industry right now?
             RamTypeRequirementsTable = TypeRequirements();
             Util.UpdateProgress(s_totalTablesCount);
 
@@ -812,7 +807,6 @@ order by 1,2,3,4";
                 InvBlueprintTypes item = new InvBlueprintTypes
                 {
                     ID = blueprint.blueprintTypeID,
-                    //ParentID = blueprint.parentBlueprintTypeID,
                 };
 
                 if (blueprint.productTypeID.HasValue)
@@ -820,9 +814,6 @@ order by 1,2,3,4";
 
                 if (blueprint.productionTime.HasValue)
                     item.ProductionTime = blueprint.productionTime.Value;
-
-                //if (blueprint.techLevel.HasValue)
-                //    item.TechLevel = blueprint.techLevel.Value;
 
                 if (blueprint.researchProductivityTime.HasValue)
                     item.ResearchProductivityTime = blueprint.researchProductivityTime.Value;
@@ -833,23 +824,11 @@ order by 1,2,3,4";
                 if (blueprint.researchCopyTime.HasValue)
                     item.ResearchCopyTime = blueprint.researchCopyTime.Value;
 
-                //if (blueprint.researchTechTime.HasValue)
-                //    item.ResearchTechTime = blueprint.researchTechTime.Value;
-
-                //if (blueprint.duplicatingTime.HasValue)
-                //    item.DuplicatingTime = blueprint.duplicatingTime.Value;
-
                 if (blueprint.reverseEngineeringTime.HasValue)
                     item.ReverseEngineeringTime = blueprint.reverseEngineeringTime.Value;
 
                 if (blueprint.inventionTime.HasValue)
                     item.InventionTime = blueprint.inventionTime.Value;
-
-                //if (blueprint.productivityModifier.HasValue)
-                //    item.ProductivityModifier = blueprint.productivityModifier.Value;
-
-                //if (blueprint.wasteFactor.HasValue)
-                //    item.WasteFactor = blueprint.wasteFactor.Value;
 
                 if (blueprint.maxProductionLimit.HasValue)
                     item.MaxProductionLimit = blueprint.maxProductionLimit.Value;
@@ -1311,20 +1290,8 @@ order by 1,2,3,4";
                 if (requirement.level.HasValue)
                     item.Level = requirement.level.Value;
 
-                //if (requirement.damagePerJob.HasValue)
-                //    item.DamagePerJob = requirement.damagePerJob.Value;
-
-                //if (requirement.recycle.HasValue)
-                //    item.Recyclable = requirement.recycle.Value;
-
-                //if (requirement.raceID.HasValue)
-                //    item.RaceID = requirement.raceID.Value;
-
                 if (requirement.probability.HasValue)
                     item.Probability = requirement.probability.Value;
-
-                //if (requirement.consume.HasValue)
-                //    item.Consume = requirement.consume.Value;
 
                 list.Add(item);
             }

--- a/tools/XmlGenerator/Providers/Database.cs
+++ b/tools/XmlGenerator/Providers/Database.cs
@@ -42,8 +42,7 @@ from invTypes it
 	left join industryActivity ia8 on ia8.typeID = it.typeID and ia8.activityID = 8";
 
         private const string ramTypeRequirementsQuery = @"
-select 	2 as sort,
-		ia.typeID,
+select 	ia.typeID,
 		ia.activityID,
 		iam.materialTypeID as requiredTypeID,
 		iam.quantity,
@@ -52,8 +51,7 @@ select 	2 as sort,
 from industryActivity ia
 	inner join industryActivityMaterials iam on ia.typeID = iam.typeID and ia.activityID = iam.activityID
 union all
-select 	1 as sort,
-		ia.typeID,
+select 	ia.typeID,
 		ia.activityID,
 		ias.skillID as requiredTypeID,
 		null as quantity,
@@ -62,16 +60,14 @@ select 	1 as sort,
 from industryActivity ia
 	inner join industryActivitySkills ias on ia.typeID = ias.typeID and ia.activityID = ias.activityID
 union all
-select 	0 as sort,
-		ia.typeID,
+select 	ia.typeID,
 		ia.activityID,
 		iap.productTypeID as requiredTypeID,
 		null as quantity,
 		null as level,
 		iap.probability
 from industryActivity ia
-	inner join industryActivityProbabilities iap on ia.typeID = iap.typeID and ia.activityID = iap.activityID
-order by 1,2,3,4";
+	inner join industryActivityProbabilities iap on ia.typeID = iap.typeID and ia.activityID = iap.activityID";
 
         #region Properties
 

--- a/tools/XmlGenerator/Providers/Database.cs
+++ b/tools/XmlGenerator/Providers/Database.cs
@@ -21,6 +21,26 @@ namespace EVEMon.XmlGenerator.Providers
         private static string s_text = string.Empty;
         private static int s_totalTablesCount;
 
+        private const string invBlueprintTypesQuery = @"
+select 	it.typeID as blueprintTypeID,
+		iap1.productTypeID,
+		ia1.time as productionTime,
+		ia3.time as researchProductivityTime,
+		ia4.time as researchMaterialTime,
+		ia5.time as researchCopyTime,
+		ia7.time as reverseEngineeringTime,
+		ia8.time as inventionTime,
+		ib.maxProductionLimit
+from invTypes it
+	inner join industryBlueprints ib on it.typeID = ib.typeID
+	left join industryActivity ia1 on ia1.typeID = it.typeID and ia1.activityID = 1
+	left join industryActivityProducts iap1 on ia1.typeID = iap1.typeID and ia1.activityID = iap1.activityID
+	left join industryActivity ia3 on ia3.typeID = it.typeID and ia3.activityID = 3
+	left join industryActivity ia4 on ia4.typeID = it.typeID and ia4.activityID = 4
+	left join industryActivity ia5 on ia5.typeID = it.typeID and ia5.activityID = 5
+	left join industryActivity ia7 on ia7.typeID = it.typeID and ia7.activityID = 7
+	left join industryActivity ia8 on ia8.typeID = it.typeID and ia8.activityID = 8";
+
         #region Properties
 
         /// <summary>
@@ -164,6 +184,11 @@ namespace EVEMon.XmlGenerator.Providers
         /// </summary>
         /// <value>The dgm attribute types table.</value>
         internal static BagCollection<InvTraits> InvTraitsTable { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the inv blueprint types able.
+        /// </summary>
+        internal static BagCollection<InvBlueprintTypes> InvBlueprintTypesTable  { get; private set; }
 
         /// <summary>
         /// Gets or sets the inv categories table.
@@ -370,8 +395,8 @@ namespace EVEMon.XmlGenerator.Providers
 
             // Find out what this used to be and find a way around it... Be interesting to see
             // if BPs apepar in the new invItems table and their traits in invTraits
-			//InvBlueprintTypesTable = BlueprintTypes();
-            //Util.UpdateProgress(s_totalTablesCount);
+			InvBlueprintTypesTable = BlueprintTypes();
+            Util.UpdateProgress(s_totalTablesCount);
 
             InvCategoriesTable = Categories();
             Util.UpdateProgress(s_totalTablesCount);
@@ -750,12 +775,12 @@ namespace EVEMon.XmlGenerator.Providers
         {
             IndexedCollection<InvBlueprintTypes> collection = new IndexedCollection<InvBlueprintTypes>();
 
-            foreach (invBlueprintTypes blueprint in s_context.invBlueprintTypes)
+            foreach (invBlueprintTypes blueprint in s_context.invBlueprintTypes.SqlQuery(invBlueprintTypesQuery))
             {
                 InvBlueprintTypes item = new InvBlueprintTypes
                 {
                     ID = blueprint.blueprintTypeID,
-                    ParentID = blueprint.parentBlueprintTypeID,
+                    //ParentID = blueprint.parentBlueprintTypeID,
                 };
 
                 if (blueprint.productTypeID.HasValue)
@@ -764,8 +789,8 @@ namespace EVEMon.XmlGenerator.Providers
                 if (blueprint.productionTime.HasValue)
                     item.ProductionTime = blueprint.productionTime.Value;
 
-                if (blueprint.techLevel.HasValue)
-                    item.TechLevel = blueprint.techLevel.Value;
+                //if (blueprint.techLevel.HasValue)
+                //    item.TechLevel = blueprint.techLevel.Value;
 
                 if (blueprint.researchProductivityTime.HasValue)
                     item.ResearchProductivityTime = blueprint.researchProductivityTime.Value;
@@ -776,11 +801,11 @@ namespace EVEMon.XmlGenerator.Providers
                 if (blueprint.researchCopyTime.HasValue)
                     item.ResearchCopyTime = blueprint.researchCopyTime.Value;
 
-                if (blueprint.researchTechTime.HasValue)
-                    item.ResearchTechTime = blueprint.researchTechTime.Value;
+                //if (blueprint.researchTechTime.HasValue)
+                //    item.ResearchTechTime = blueprint.researchTechTime.Value;
 
-                if (blueprint.duplicatingTime.HasValue)
-                    item.DuplicatingTime = blueprint.duplicatingTime.Value;
+                //if (blueprint.duplicatingTime.HasValue)
+                //    item.DuplicatingTime = blueprint.duplicatingTime.Value;
 
                 if (blueprint.reverseEngineeringTime.HasValue)
                     item.ReverseEngineeringTime = blueprint.reverseEngineeringTime.Value;
@@ -788,11 +813,11 @@ namespace EVEMon.XmlGenerator.Providers
                 if (blueprint.inventionTime.HasValue)
                     item.InventionTime = blueprint.inventionTime.Value;
 
-                if (blueprint.productivityModifier.HasValue)
-                    item.ProductivityModifier = blueprint.productivityModifier.Value;
+                //if (blueprint.productivityModifier.HasValue)
+                //    item.ProductivityModifier = blueprint.productivityModifier.Value;
 
-                if (blueprint.wasteFactor.HasValue)
-                    item.WasteFactor = blueprint.wasteFactor.Value;
+                //if (blueprint.wasteFactor.HasValue)
+                //    item.WasteFactor = blueprint.wasteFactor.Value;
 
                 if (blueprint.maxProductionLimit.HasValue)
                     item.MaxProductionLimit = blueprint.maxProductionLimit.Value;

--- a/tools/XmlGenerator/StaticData/InvBlueprintTypes.cs
+++ b/tools/XmlGenerator/StaticData/InvBlueprintTypes.cs
@@ -8,17 +8,11 @@ namespace EVEMon.XmlGenerator.StaticData
         [XmlElement("blueprintTypeID")]
         public int ID { get; set; }
 
-        //[XmlElement("parentBlueprintTypeID")]
-        //public int? ParentID { get; set; }
-
         [XmlElement("productTypeID")]
         public int ProductTypeID { get; set; }
 
         [XmlElement("productionTime")]
         public int ProductionTime { get; set; }
-
-        //[XmlElement("techLevel")]
-        //public short TechLevel { get; set; }
 
         [XmlElement("researchProductivityTime")]
         public int ResearchProductivityTime { get; set; }
@@ -29,23 +23,11 @@ namespace EVEMon.XmlGenerator.StaticData
         [XmlElement("researchCopyTime")]
         public int ResearchCopyTime { get; set; }
 
-        //[XmlElement("researchTechTime")]
-        //public int ResearchTechTime { get; set; }
-
-        //[XmlAttribute("duplicatingTime")]
-        //public int DuplicatingTime { get; set; }
-
         [XmlAttribute("reverseEngineeringTime")]
         public int ReverseEngineeringTime { get; set; }
 
         [XmlAttribute("inventionTime")]
         public int InventionTime { get; set; }
-
-        //[XmlElement("productivityModifier")]
-        //public int ProductivityModifier { get; set; }
-
-        //[XmlElement("wasteFactor")]
-        //public short WasteFactor { get; set; }
 
         [XmlElement("maxProductionLimit")]
         public int MaxProductionLimit { get; set; }

--- a/tools/XmlGenerator/StaticData/InvBlueprintTypes.cs
+++ b/tools/XmlGenerator/StaticData/InvBlueprintTypes.cs
@@ -8,8 +8,8 @@ namespace EVEMon.XmlGenerator.StaticData
         [XmlElement("blueprintTypeID")]
         public int ID { get; set; }
 
-        [XmlElement("parentBlueprintTypeID")]
-        public int? ParentID { get; set; }
+        //[XmlElement("parentBlueprintTypeID")]
+        //public int? ParentID { get; set; }
 
         [XmlElement("productTypeID")]
         public int ProductTypeID { get; set; }
@@ -17,8 +17,8 @@ namespace EVEMon.XmlGenerator.StaticData
         [XmlElement("productionTime")]
         public int ProductionTime { get; set; }
 
-        [XmlElement("techLevel")]
-        public short TechLevel { get; set; }
+        //[XmlElement("techLevel")]
+        //public short TechLevel { get; set; }
 
         [XmlElement("researchProductivityTime")]
         public int ResearchProductivityTime { get; set; }
@@ -29,11 +29,11 @@ namespace EVEMon.XmlGenerator.StaticData
         [XmlElement("researchCopyTime")]
         public int ResearchCopyTime { get; set; }
 
-        [XmlElement("researchTechTime")]
-        public int ResearchTechTime { get; set; }
+        //[XmlElement("researchTechTime")]
+        //public int ResearchTechTime { get; set; }
 
-        [XmlAttribute("duplicatingTime")]
-        public int DuplicatingTime { get; set; }
+        //[XmlAttribute("duplicatingTime")]
+        //public int DuplicatingTime { get; set; }
 
         [XmlAttribute("reverseEngineeringTime")]
         public int ReverseEngineeringTime { get; set; }
@@ -41,11 +41,11 @@ namespace EVEMon.XmlGenerator.StaticData
         [XmlAttribute("inventionTime")]
         public int InventionTime { get; set; }
 
-        [XmlElement("productivityModifier")]
-        public int ProductivityModifier { get; set; }
+        //[XmlElement("productivityModifier")]
+        //public int ProductivityModifier { get; set; }
 
-        [XmlElement("wasteFactor")]
-        public short WasteFactor { get; set; }
+        //[XmlElement("wasteFactor")]
+        //public short WasteFactor { get; set; }
 
         [XmlElement("maxProductionLimit")]
         public int MaxProductionLimit { get; set; }

--- a/tools/XmlGenerator/StaticData/RamTypeRequirements.cs
+++ b/tools/XmlGenerator/StaticData/RamTypeRequirements.cs
@@ -20,19 +20,19 @@ namespace EVEMon.XmlGenerator.StaticData
         [XmlElement("level")]
         public int? Level { get; set; }
 
-        [XmlElement("damagePerJob")]
-        public double? DamagePerJob { get; set; }
+        //[XmlElement("damagePerJob")]
+        //public double? DamagePerJob { get; set; }
 
-        [XmlElement("recycle")]
-        public bool? Recyclable { get; set; }
+        //[XmlElement("recycle")]
+        //public bool? Recyclable { get; set; }
 
-        [XmlElement("raceID")]
-        public int? RaceID { get; set; }
+        //[XmlElement("raceID")]
+        //public int? RaceID { get; set; }
 
         [XmlElement("probability")]
         public double? Probability { get; set; }
 
-        [XmlElement("consume")]
-        public bool? Consume { get; set; }
+        //[XmlElement("consume")]
+        //public bool? Consume { get; set; }
     }
 }

--- a/tools/XmlGenerator/StaticData/RamTypeRequirements.cs
+++ b/tools/XmlGenerator/StaticData/RamTypeRequirements.cs
@@ -20,19 +20,7 @@ namespace EVEMon.XmlGenerator.StaticData
         [XmlElement("level")]
         public int? Level { get; set; }
 
-        //[XmlElement("damagePerJob")]
-        //public double? DamagePerJob { get; set; }
-
-        //[XmlElement("recycle")]
-        //public bool? Recyclable { get; set; }
-
-        //[XmlElement("raceID")]
-        //public int? RaceID { get; set; }
-
         [XmlElement("probability")]
         public double? Probability { get; set; }
-
-        //[XmlElement("consume")]
-        //public bool? Consume { get; set; }
     }
 }


### PR DESCRIPTION
This will fix #114 

Something that this doesn't fix is the market group of newer blueprints that don't have one in the SDE
For example the blueprints for the new AT ships like Hydra is showing as Various Non-Market > Tech I
This is because they are all hard-coded in Blueprints.cs, see the method SetMarketGroupManually

A lot of existing blueprints have also shifted over to the "Various non-market" group in their respective subgroup (T1, T2, T3, faction, etc).
This might be avoidable somehow, if we can inject the old market group to the blueprint somehow. I haven't put any time into it yet.

I have not included the updated xml files in this pull request as I am not sure if there are other steps required than running it and committing the updated gzip and md5 files.
I've only tried this with the newest sqlite dump from fuzzworks, and it causes some changes to items, properties, reprocessing and skills as well. I'm assuming that those are legit, as I didn't modify the code for them.

I have only been able to do a superficial compare of the old and new files due to the sorting in the newly generated file to be different than the old one.
All of the samples I've taken of blueprints that were removed from a certain place in the file were either removed from the game or were moved to another market group as described above.
The blueprints that were missing before (For example Standup Cap Battery I Blueprint) are now in the file.