### PR TITLE
Update to fix exception when navigating Ship Browser

### DIFF
--- a/src/EVEMon/SkillPlanner/MasteryTreeDisplayControl.cs
+++ b/src/EVEMon/SkillPlanner/MasteryTreeDisplayControl.cs
@@ -743,10 +743,15 @@ namespace EVEMon.SkillPlanner
             // When a skill is selected, we select it in the skill browser
             else
             {
-                Skill skill = ((SkillLevel)treeView.SelectedNode?.Tag)?.Skill;
+                SkillLevel skillLevel = treeView.SelectedNode?.Tag as SkillLevel;
 
-                // Open the skill browser
-                PlanWindow.ShowPlanWindow(m_character, m_plan).ShowSkillInBrowser(skill);
+                if (skillLevel != null)
+                {
+                    Skill skill = skillLevel.Skill;
+
+                    // Open the skill browser
+                    PlanWindow.ShowPlanWindow(m_character, m_plan).ShowSkillInBrowser(skill);
+                }
             }
         }
 


### PR DESCRIPTION
When navigating in the Ship Browser and selecting a level of mastery, double clicking on it results in the client attempting to cast to the wrong type, throwing an exception and crashing.  This fixes that by checking the type and doing nothing if the wrong node is clicked.