### PR TITLE
Reaction industry job output

### DIFF
--- a/src/EVEMon.Common/Data/Blueprint.cs
+++ b/src/EVEMon.Common/Data/Blueprint.cs
@@ -29,6 +29,9 @@ namespace EVEMon.Common.Data
             ResearchProductivityTime = src.ResearchProductivityTime;
             ResearchInventionTime = src.InventionTime;
             ReverseEngineeringTime = src.ReverseEngineeringTime;
+            ReactionTime = src.ReactionTime;
+            if (src.ReactionOutcome != null)
+                ReactionOutcome = new Material(src.ReactionOutcome);
 
             // Invented blueprints
             m_inventBlueprints = new Dictionary<int, decimal>(src.InventionTypeIDs?.Count ?? 0);
@@ -93,6 +96,16 @@ namespace EVEMon.Common.Data
         /// Gets the reverse engineering time.
         /// </summary>
         public double ReverseEngineeringTime { get; private set; }
+
+        /// <summary>
+        /// Gets the reaction time.
+        /// </summary>
+        public double ReactionTime { get; private set; }
+
+        /// <summary>
+        /// Gets the reaction outcome material.
+        /// </summary>
+        public Material ReactionOutcome { get; private set; }
 
         /// <summary>
         /// Gets the collection of materials this blueprint must satisfy to be build.

--- a/src/EVEMon.Common/Enumerations/BlueprintActivity.cs
+++ b/src/EVEMon.Common/Enumerations/BlueprintActivity.cs
@@ -32,6 +32,9 @@ namespace EVEMon.Common.Enumerations
         ReverseEngineering = 7,
 
         [Description("Invention")]
-        Invention = 8
+        Invention = 8,
+
+        [Description("Reactions")]
+        Reactions = 11
     }
 }

--- a/src/EVEMon.Common/Models/IndustryJob.cs
+++ b/src/EVEMon.Common/Models/IndustryJob.cs
@@ -346,6 +346,8 @@ namespace EVEMon.Common.Models
                 case BlueprintActivity.Invention:
                 case BlueprintActivity.ReverseEngineering:
                     return StaticBlueprints.GetBlueprintByID(id) ?? StaticItems.GetItemByID(0);
+                case BlueprintActivity.Reactions:
+                    return StaticItems.GetItemByID(InstalledItem?.ReactionOutcome?.Item?.ID ?? 0);
                 default:
                     return StaticItems.GetItemByID(0);
             }

--- a/src/EVEMon.Common/Serialization/Datafiles/SerializableBlueprint.cs
+++ b/src/EVEMon.Common/Serialization/Datafiles/SerializableBlueprint.cs
@@ -105,6 +105,13 @@ namespace EVEMon.Common.Serialization.Datafiles
         public int InventionTime { get; set; }
 
         /// <summary>
+        /// Gets or sets the reaction time.
+        /// </summary>
+        /// <value>The reaction time.</value>
+        [XmlAttribute("reactionTime")]
+        public int ReactionTime { get; set; }
+
+        /// <summary>
         /// Gets or sets the max production limit.
         /// </summary>
         /// <value>The max production limit.</value>
@@ -117,6 +124,13 @@ namespace EVEMon.Common.Serialization.Datafiles
         /// <value>The invention type ID.</value>
         [XmlElement("inventTypeIDs")]
         public ModifiedSerializableDictionary<int, decimal> InventionTypeIDs { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reaction outcome.
+        /// </summary>
+        /// <value>The reaction outcome.</value>
+        [XmlElement("reactionOutcome")]
+        public SerializableMaterialQuantity ReactionOutcome { get; set; }
 
         /// <summary>
         /// Gets the prereq skill.

--- a/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.cs
@@ -754,13 +754,18 @@ namespace EVEMon.CharacterMonitoring
         /// </summary>
         /// <param name="job">The job.</param>
         /// <returns></returns>
-        private static int GetUnitCount(IndustryJob job)
+        private static long GetUnitCount(IndustryJob job)
         {
-            if (job.Activity != BlueprintActivity.Manufacturing)
-                return 1;
-
-            // Returns the ammount produced
-            return job.Runs * job.OutputItem.PortionSize;
+            switch (job.Activity)
+            {
+                case BlueprintActivity.Manufacturing:
+                    // Returns the amount produced
+                    return job.Runs * job.OutputItem.PortionSize;
+                case BlueprintActivity.Reactions:
+                    return job.Runs * job.InstalledItem.ReactionOutcome.Quantity;
+                default:
+                    return 1;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Disclaimer: This is a bit WIP, and has not been tested with data from ESI

In order to properly support reactions there is a bit more work needed:
The number of available/used reaction jobs is still missing
The blueprint browser needs some love, and there's also a bunch of existing code that uses the old reaction system, which should probably be removed.
But this should make the industry jobs list show the correct output type and quantity.