### PR TITLE
Add Loyalty Point list as advanced feature, fixes #138

### DIFF
--- a/src/EVEMon.Common/Collections/Global/GlobalNotificationCollection.cs
+++ b/src/EVEMon.Common/Collections/Global/GlobalNotificationCollection.cs
@@ -1034,6 +1034,24 @@ namespace EVEMon.Common.Collections.Global
             Notify(notification);
         }
 
+        /// <summary>
+        /// Notifies a loyalty query error.
+        /// </summary>
+        /// <param name="character">The character.</param>
+        /// <param name="result">The result.</param>
+        internal void NotifyCharacterLoyaltyPointsError(CCPCharacter character,
+            EsiResult<EsiAPILoyality> result)
+        {
+            var notification = new APIErrorNotificationEventArgs(character, result)
+            {
+                Description = string.Format(Properties.Resources.ErrorLoyalty,
+                    character?.Name),
+                Behaviour = NotificationBehaviour.Overwrite,
+                Priority = NotificationPriority.Error
+            };
+            Notify(notification);
+        }
+
         #endregion
 
 

--- a/src/EVEMon.Common/Constants/NetworkConstants.resx
+++ b/src/EVEMon.Common/Constants/NetworkConstants.resx
@@ -627,4 +627,8 @@
   <data name="PostDataRefreshPKCE" xml:space="preserve">
     <value>grant_type=refresh_token&amp;client_id={1}&amp;refresh_token={0}</value>
   </data>
+  <data name="ESILoyaltyPoints" xml:space="preserve">
+    <value>/v1/characters/{0:D}/loyalty/points/</value>
+    <comment>3600</comment>
+  </data>
 </root>

--- a/src/EVEMon.Common/Constants/NetworkConstants1.Designer.cs
+++ b/src/EVEMon.Common/Constants/NetworkConstants1.Designer.cs
@@ -682,6 +682,15 @@ namespace EVEMon.Common.Constants {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to /v1/characters/{0:D}/loyalty/points/.
+        /// </summary>
+        public static string ESILoyaltyPoints {
+            get {
+                return ResourceManager.GetString("ESILoyaltyPoints", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to /v1/characters/{0:D}/mail/{1:D}/.
         /// </summary>
         public static string ESIMailBodies {

--- a/src/EVEMon.Common/EVEMon.Common.csproj
+++ b/src/EVEMon.Common/EVEMon.Common.csproj
@@ -220,6 +220,7 @@
     <Compile Include="Extensions\HttpExtensions.cs" />
     <Compile Include="Extensions\ObjectExtensions.cs" />
     <Compile Include="Helpers\BlankCharacterUIHelper.cs" />
+    <Compile Include="Helpers\ImageHelper.cs" />
     <Compile Include="Helpers\TaskHelper.cs" />
     <Compile Include="Models\AccountStatus.cs" />
     <Compile Include="Models\ESIMethod.cs" />

--- a/src/EVEMon.Common/EVEMon.Common.csproj
+++ b/src/EVEMon.Common/EVEMon.Common.csproj
@@ -224,13 +224,17 @@
     <Compile Include="Models\AccountStatus.cs" />
     <Compile Include="Models\ESIMethod.cs" />
     <Compile Include="Models\Extended\ESIMethods.cs" />
+    <Compile Include="Models\Loyalty.cs" />
+    <Compile Include="Models\Collections\LoyaltyCollection.cs" />
     <Compile Include="Net\HttpWebClientService.StringDownload.cs" />
     <Compile Include="Net\RequestParams.cs" />
     <Compile Include="Net\ResponseParams.cs" />
     <Compile Include="QueryMonitor\CCPQueryMonitorBase.cs" />
     <Compile Include="QueryMonitor\PagedQueryMonitor.cs" />
     <Compile Include="Serialization\Datafiles\SerializablePlanet.cs" />
+    <Compile Include="Serialization\Esi\EsiLoyaltyListItem.cs" />
     <Compile Include="Serialization\Esi\EsiAPIContactsList.cs" />
+    <Compile Include="Serialization\Esi\EsiAPILoyalty.cs" />
     <Compile Include="Serialization\Esi\EsiAPIMedals.cs" />
     <Compile Include="Serialization\Esi\EsiAPIPlanet.cs" />
     <Compile Include="Serialization\Esi\EsiErrors.cs" />

--- a/src/EVEMon.Common/Enumerations/CCPAPI/CCPAPIMethodsEnum.cs
+++ b/src/EVEMon.Common/Enumerations/CCPAPI/CCPAPIMethodsEnum.cs
@@ -36,7 +36,7 @@ namespace EVEMon.Common.Enumerations.CCPAPI
             ESIAPICharacterMethods.Standings | ESIAPICharacterMethods.UpcomingCalendarEvents |
             ESIAPICharacterMethods.UpcomingCalendarEventDetails |
             ESIAPICharacterMethods.WalletJournal | ESIAPICharacterMethods.WalletTransactions |
-            ESIAPICharacterMethods.CitadelInfo,
+            ESIAPICharacterMethods.CitadelInfo | ESIAPICharacterMethods.LoyaltyPoints,
 
         /// <summary>
         /// The advanced corporation features of APIMethodsEnum.

--- a/src/EVEMon.Common/Enumerations/CCPAPI/ESIAPICharacterMethods.cs
+++ b/src/EVEMon.Common/Enumerations/CCPAPI/ESIAPICharacterMethods.cs
@@ -140,6 +140,14 @@ namespace EVEMon.Common.Enumerations.CCPAPI
         Location = 1 << 17,
 
         /// <summary>
+        /// A character's loyalty point balances.
+        /// </summary>
+        [Header("Loyalty Points")]
+        [Description("The Loyalty Point balances of a character.")]
+        [Update(UpdatePeriod.Hours2, UpdatePeriod.Hours1)]
+        LoyaltyPoints = (long)1 << 36,
+
+        /// <summary>
         /// Mail messages for a character.
         /// </summary>
         [Header("EVE Mail Messages")]

--- a/src/EVEMon.Common/EveMonClient.Events.cs
+++ b/src/EVEMon.Common/EveMonClient.Events.cs
@@ -303,7 +303,12 @@ namespace EVEMon.Common
         /// Occurs when the character planetary colony layout has been updated.
         /// </summary>
         public static event EventHandler<CharacterChangedEventArgs> CharacterPlanetaryLayoutUpdated;
-        
+
+        /// <summary>
+        /// Occurs when the character loyalty point balances have been updated.
+        /// </summary>
+        public static event EventHandler<CharacterChangedEventArgs> CharacterLoyaltyPointsUpdated;
+
         /// <summary>
         /// Occurs when a plan's name changed.
         /// </summary>
@@ -1031,7 +1036,20 @@ namespace EVEMon.Common
             Trace(character.Name);
             CharacterPlanetaryLayoutUpdated?.ThreadSafeInvoke(null, new CharacterChangedEventArgs(character));
         }
-        
+
+        /// <summary>
+        /// Called when the character loyalty point balances updated.
+        /// </summary>
+        /// <param name="character">The character.</param>
+        internal static void OnCharacterLoyaltyPointsUpdated(Character character)
+        {
+            if (Closed)
+                return;
+
+            Trace(character.Name);
+            CharacterLoyaltyPointsUpdated?.ThreadSafeInvoke(null, new CharacterChangedEventArgs(character));
+        }
+
         /// <summary>
         /// Called when the character portrait updated.
         /// </summary>

--- a/src/EVEMon.Common/Helpers/ImageHelper.cs
+++ b/src/EVEMon.Common/Helpers/ImageHelper.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using EVEMon.Common.Constants;
+using EVEMon.Common.Enumerations;
+using EVEMon.Common.Service;
+
+namespace EVEMon.Common.Helpers
+{
+    public static class ImageHelper
+    {
+        private const string NO_TYPE = "";
+
+        /// <summary>
+        /// Gets the URL for the image of the specified type and ID.
+        /// </summary>
+        /// <param name="useFallbackUri">if set to <c>true</c> [use fallback URI].</param>
+        /// <param name="type">the type of the ID.</param>
+        /// <param name="id">the ID for the given type.</param>
+        /// <param name="size">the image size.</param>
+        /// <returns></returns>
+        public static Uri GetImageUrl(bool useFallbackUri, string type, long id, int size = (int)EveImageSize.x32)
+        {
+            return GetImageUrlHelper(NetworkConstants.CCPIconsFromImageServer, useFallbackUri, type, id, size);
+        }
+
+        /// <summary>
+        /// Gets the URL for the portrait of the specified character.
+        /// </summary>
+        /// <param name="useFallbackUri">if set to <c>true</c> [use fallback URI].</param>
+        /// <param name="id">the ID for the character.</param>
+        /// <param name="size">the image size.</param>
+        /// <returns></returns>
+        public static Uri GetPortraitUrl(bool useFallbackUri, long id, int size = (int)EveImageSize.x32)
+        {
+            return GetImageUrlHelper(NetworkConstants.CCPPortraits, useFallbackUri, NO_TYPE, id, size);
+        }
+
+        /// <summary>
+        /// Helper function to get a potrait or icon URL, based on parameters.
+        /// </summary>
+        private static Uri GetImageUrlHelper(string format, bool useFallbackUri, string type, long id, int size)
+        {
+            string path = type == NO_TYPE
+                ? string.Format(CultureConstants.InvariantCulture, format, id, size)
+                : string.Format(CultureConstants.InvariantCulture, format, type, id, size);
+
+            return useFallbackUri
+                ? ImageService.GetImageServerBaseUri(path)
+                : ImageService.GetImageServerCdnUri(path);
+        }
+    }
+}

--- a/src/EVEMon.Common/Models/CCPCharacter.cs
+++ b/src/EVEMon.Common/Models/CCPCharacter.cs
@@ -74,6 +74,7 @@ namespace EVEMon.Common.Models
             UpcomingCalendarEvents = new UpcomingCalendarEventCollection(this);
             KillLog = new KillLogCollection(this);
             PlanetaryColonies = new PlanetaryColonyCollection(this);
+            LoyaltyPoints = new LoyaltyCollection(this);
 
             m_endedOrdersForCharacter = new List<MarketOrder>();
             m_endedOrdersForCorporation = new List<MarketOrder>();
@@ -270,6 +271,11 @@ namespace EVEMon.Common.Models
         /// Gets the collection of planetary colonies.
         /// </summary>
         public PlanetaryColonyCollection PlanetaryColonies { get; }
+
+        /// <summary>
+        /// Gets the collection of loyalty points.
+        /// </summary>
+        public LoyaltyCollection LoyaltyPoints { get; }
 
         /// <summary>
         /// Gets the query monitors enumeration.

--- a/src/EVEMon.Common/Models/Collections/LoyaltyCollection.cs
+++ b/src/EVEMon.Common/Models/Collections/LoyaltyCollection.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using EVEMon.Common.Collections;
+using EVEMon.Common.Serialization.Esi;
+
+namespace EVEMon.Common.Models.Collections
+{
+    public sealed class LoyaltyCollection : ReadonlyCollection<Loyalty>
+    {
+        private readonly CCPCharacter m_character;
+
+        /// <summary>
+        /// Internal constructor.
+        /// </summary>
+        /// <param name="character">The character.</param>
+        internal LoyaltyCollection(CCPCharacter character)
+        {
+            m_character = character;
+        }
+
+        /// <summary>
+        /// Imports an enumeration of API objects.
+        /// </summary>
+        /// <param name="src">The enumeration of serializable loyalty point info from the API.</param>
+        internal void Import(IEnumerable<EsiLoyaltyListItem> src)
+        {
+            Items.Clear();
+
+            // Import the loyalty point info from the API
+            foreach (EsiLoyaltyListItem srcloyalty in src)
+            {
+                Items.Add(new Loyalty(m_character, srcloyalty));
+            }
+        }
+    }
+}

--- a/src/EVEMon.Common/Models/Contact.cs
+++ b/src/EVEMon.Common/Models/Contact.cs
@@ -2,10 +2,10 @@ using System;
 using System.Drawing;
 using System.Linq;
 using System.Threading.Tasks;
-using EVEMon.Common.Constants;
 using EVEMon.Common.Data;
 using EVEMon.Common.Enumerations;
 using EVEMon.Common.Extensions;
+using EVEMon.Common.Helpers;
 using EVEMon.Common.Service;
 using EVEMon.Common.Serialization.Esi;
 
@@ -157,18 +157,11 @@ namespace EVEMon.Common.Models
         /// <returns></returns>
         private Uri GetImageUrl(bool useFallbackUri)
         {
-            string path = m_contactType == ContactType.Character
-                ? string.Format(CultureConstants.InvariantCulture,
-                    NetworkConstants.CCPPortraits,
-                    m_contactID, (int)EveImageSize.x32)
-                : string.Format(CultureConstants.InvariantCulture,
-                    NetworkConstants.CCPIconsFromImageServer,
-                    m_contactType == ContactType.Alliance ? "alliance" : "corporation",
-                    m_contactID, (int)EveImageSize.x32);
-
-            return useFallbackUri
-                ? ImageService.GetImageServerBaseUri(path)
-                : ImageService.GetImageServerCdnUri(path);
+            return m_contactType == ContactType.Character
+                ? ImageHelper.GetPortraitUrl(useFallbackUri, m_contactID)
+                : ImageHelper.GetImageUrl(useFallbackUri,
+                m_contactType == ContactType.Alliance ? "alliance" : "corporation",
+                m_contactID);
         }
 
         #endregion

--- a/src/EVEMon.Common/Models/EmploymentRecord.cs
+++ b/src/EVEMon.Common/Models/EmploymentRecord.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using EVEMon.Common.Constants;
 using EVEMon.Common.Enumerations;
 using EVEMon.Common.Extensions;
+using EVEMon.Common.Helpers;
 using EVEMon.Common.Serialization.Eve;
 using EVEMon.Common.Service;
 
@@ -108,7 +109,8 @@ namespace EVEMon.Common.Models
         {
             while (true)
             {
-                Image img = await ImageService.GetImageAsync(GetImageUrl(useFallbackUri)).ConfigureAwait(false);
+                Uri uri = ImageHelper.GetImageUrl(useFallbackUri, "corporation", m_corporationId);
+                Image img = await ImageService.GetImageAsync(uri).ConfigureAwait(false);
 
                 if (img == null)
                 {
@@ -125,22 +127,6 @@ namespace EVEMon.Common.Models
                 break;
             }
         }
-
-        /// <summary>
-        /// Gets the image URL.
-        /// </summary>
-        /// <param name="useFallbackUri">if set to <c>true</c> [use fallback URI].</param>
-        /// <returns></returns>
-        private Uri GetImageUrl(bool useFallbackUri)
-        {
-            string path = string.Format(CultureConstants.InvariantCulture,
-                NetworkConstants.CCPIconsFromImageServer, "corporation", m_corporationId, (int)EveImageSize.x32);
-
-            return useFallbackUri
-                ? ImageService.GetImageServerBaseUri(path)
-                : ImageService.GetImageServerCdnUri(path);
-        }
-
 
         #endregion
 

--- a/src/EVEMon.Common/Models/KillLog.cs
+++ b/src/EVEMon.Common/Models/KillLog.cs
@@ -7,6 +7,7 @@ using EVEMon.Common.Constants;
 using EVEMon.Common.Data;
 using EVEMon.Common.Enumerations;
 using EVEMon.Common.Extensions;
+using EVEMon.Common.Helpers;
 using EVEMon.Common.Serialization.Eve;
 using EVEMon.Common.Service;
 using EVEMon.Common.Serialization.Esi;
@@ -162,7 +163,8 @@ namespace EVEMon.Common.Models
         {
             while (true)
             {
-                Image img = await ImageService.GetImageAsync(GetImageUrl(useFallbackUri)).ConfigureAwait(false);
+                Uri uri = ImageHelper.GetImageUrl(useFallbackUri, "type", Victim.ShipTypeID);
+                Image img = await ImageService.GetImageAsync(uri).ConfigureAwait(false);
 
                 if (img == null)
                 {
@@ -210,21 +212,6 @@ namespace EVEMon.Common.Models
         /// </summary>
         /// <returns></returns>
         private static Bitmap GetDefaultImage() => new Bitmap(32, 32);
-
-        /// <summary>
-        /// Gets the image URL.
-        /// </summary>
-        /// <param name="useFallbackUri">if set to <c>true</c> [use fallback URI].</param>
-        /// <returns></returns>
-        private Uri GetImageUrl(bool useFallbackUri)
-        {
-            string path = string.Format(CultureConstants.InvariantCulture,
-                NetworkConstants.CCPIconsFromImageServer, "type", Victim.ShipTypeID,
-                (int)EveImageSize.x32);
-
-            return useFallbackUri ? ImageService.GetImageServerBaseUri(path) :
-                ImageService.GetImageServerCdnUri(path);
-        }
 
         #endregion
 

--- a/src/EVEMon.Common/Models/KillLogItem.cs
+++ b/src/EVEMon.Common/Models/KillLogItem.cs
@@ -7,6 +7,7 @@ using EVEMon.Common.Constants;
 using EVEMon.Common.Data;
 using EVEMon.Common.Enumerations;
 using EVEMon.Common.Extensions;
+using EVEMon.Common.Helpers;
 using EVEMon.Common.Serialization.Eve;
 using EVEMon.Common.Service;
 
@@ -244,7 +245,8 @@ namespace EVEMon.Common.Models
         {
             while (true)
             {
-                Image img = await ImageService.GetImageAsync(GetImageUrl(useFallbackUri)).ConfigureAwait(false);
+                Uri uri = ImageHelper.GetImageUrl(useFallbackUri, "type", m_typeID);
+                Image img = await ImageService.GetImageAsync(uri).ConfigureAwait(false);
 
                 if (img == null)
                 {
@@ -268,22 +270,6 @@ namespace EVEMon.Common.Models
         /// </summary>
         /// <returns></returns>
         private static Bitmap GetDefaultImage() => new Bitmap(24, 24);
-
-        /// <summary>
-        /// Gets the image URL.
-        /// </summary>
-        /// <param name="useFallbackUri">if set to <c>true</c> [use fallback URI].</param>
-        /// <returns></returns>
-        private Uri GetImageUrl(bool useFallbackUri)
-        {
-            string path = string.Format(CultureConstants.InvariantCulture,
-                NetworkConstants.CCPIconsFromImageServer, "type", m_typeID,
-                (int)EveImageSize.x32);
-
-            return useFallbackUri
-                ? ImageService.GetImageServerBaseUri(path)
-                : ImageService.GetImageServerCdnUri(path);
-        }
 
         #endregion
     }

--- a/src/EVEMon.Common/Models/Loyalty.cs
+++ b/src/EVEMon.Common/Models/Loyalty.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Threading.Tasks;
+using EVEMon.Common.Serialization.Esi;
+
+namespace EVEMon.Common.Models
+{
+    public sealed class Loyalty
+    {
+        #region Fields
+
+        private readonly Character m_character;
+
+        #endregion
+
+
+        #region Constructor
+
+        /// <summary>
+        /// Constructor from the API.
+        /// </summary>
+        /// <param name="character"></param>
+        /// <param name="src"></param>
+        internal Loyalty(Character character, EsiLoyaltyListItem src)
+        {
+            m_character = character;
+
+            LoyaltyPoints = src.LoyaltyPoints;
+            CorpId = src.CorpID;
+        }
+
+        #endregion
+
+
+        #region Public Properties
+
+        /// <summary>
+        /// Gets or sets the loyalty point value.
+        /// </summary>
+        /// <value>The loyalty point value.</value>
+        public int LoyaltyPoints { get; }
+
+        /// <summary>
+        /// Gets or sets the corp ID.
+        /// </summary>
+        /// <value>The corp ID.</value>
+        public int CorpId { get; }
+
+        #endregion
+
+
+        #region Helper Methods
+
+
+
+        #endregion
+    }
+}

--- a/src/EVEMon.Common/Models/Loyalty.cs
+++ b/src/EVEMon.Common/Models/Loyalty.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Drawing;
 using System.Threading.Tasks;
+using EVEMon.Common.Extensions;
 using EVEMon.Common.Serialization.Esi;
+using EVEMon.Common.Service;
 
 namespace EVEMon.Common.Models
 {
@@ -10,6 +13,9 @@ namespace EVEMon.Common.Models
 
         private readonly Character m_character;
 
+        private string m_corporationName;
+        private Image m_image;
+
         #endregion
 
 
@@ -18,20 +24,29 @@ namespace EVEMon.Common.Models
         /// <summary>
         /// Constructor from the API.
         /// </summary>
-        /// <param name="character"></param>
-        /// <param name="src"></param>
+        /// <param name="character">The character.</param>
+        /// <param name="src">The source.</param>
+        /// <exception cref="System.ArgumentNullException">src</exception>
         internal Loyalty(Character character, EsiLoyaltyListItem src)
         {
             m_character = character;
 
             LoyaltyPoints = src.LoyaltyPoints;
             CorpId = src.CorpID;
+            m_corporationName = EveIDToName.GetIDToName(src.CorpID);
         }
 
         #endregion
 
 
         #region Public Properties
+
+        /// <summary>
+        /// Gets or sets the name of the corporation.
+        /// </summary>
+        /// <value>The name of the corporation.</value>
+        public string CorporationName => m_corporationName.IsEmptyOrUnknown() ?
+            (m_corporationName = EveIDToName.GetIDToName(CorpId)) : m_corporationName;
 
         /// <summary>
         /// Gets or sets the loyalty point value.

--- a/src/EVEMon.Common/Models/Loyalty.cs
+++ b/src/EVEMon.Common/Models/Loyalty.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Drawing;
 using System.Threading.Tasks;
-using EVEMon.Common.Constants;
-using EVEMon.Common.Enumerations;
 using EVEMon.Common.Extensions;
+using EVEMon.Common.Helpers;
 using EVEMon.Common.Serialization.Esi;
 using EVEMon.Common.Service;
 
@@ -94,7 +93,8 @@ namespace EVEMon.Common.Models
         {
             while (true)
             {
-                Image img = await ImageService.GetImageAsync(GetImageUrl(useFallbackUri)).ConfigureAwait(false);
+                Uri uri = ImageHelper.GetImageUrl(useFallbackUri, "corporation", CorpId);
+                Image img = await ImageService.GetImageAsync(uri).ConfigureAwait(false);
 
                 if (img == null)
                 {
@@ -110,21 +110,6 @@ namespace EVEMon.Common.Models
                 LoyaltyCorpImageUpdated?.ThreadSafeInvoke(this, EventArgs.Empty);
                 break;
             }
-        }
-
-        /// <summary>
-        /// Gets the image URL.
-        /// </summary>
-        /// <param name="useFallbackUri">if set to <c>true</c> [use fallback URI].</param>
-        /// <returns></returns>
-        private Uri GetImageUrl(bool useFallbackUri)
-        {
-            string path = string.Format(CultureConstants.InvariantCulture,
-                NetworkConstants.CCPIconsFromImageServer, "corporation", CorpId, (int)EveImageSize.x32);
-
-            return useFallbackUri
-                ? ImageService.GetImageServerBaseUri(path)
-                : ImageService.GetImageServerCdnUri(path);
         }
 
         #endregion

--- a/src/EVEMon.Common/Models/Standing.cs
+++ b/src/EVEMon.Common/Models/Standing.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using EVEMon.Common.Constants;
 using EVEMon.Common.Enumerations;
 using EVEMon.Common.Extensions;
+using EVEMon.Common.Helpers;
 using EVEMon.Common.Service;
 using EVEMon.Common.Serialization.Esi;
 
@@ -191,18 +192,11 @@ namespace EVEMon.Common.Models
         /// <returns></returns>
         private Uri GetImageUrl(bool useFallbackUri)
         {
-            string path = Group == StandingGroup.Agents
-                ? string.Format(CultureConstants.InvariantCulture,
-                    NetworkConstants.CCPPortraits,
-                    m_entityID, (int)EveImageSize.x32)
-                : string.Format(CultureConstants.InvariantCulture,
-                    NetworkConstants.CCPIconsFromImageServer,
-                    Group == StandingGroup.Factions ? "alliance" : "corporation",
-                    m_entityID, (int)EveImageSize.x32);
-
-            return useFallbackUri
-                ? ImageService.GetImageServerBaseUri(path)
-                : ImageService.GetImageServerCdnUri(path);
+            return Group == StandingGroup.Agents
+                ? ImageHelper.GetPortraitUrl(useFallbackUri, m_entityID)
+                : ImageHelper.GetImageUrl(useFallbackUri,
+                Group == StandingGroup.Factions ? "alliance" : "corporation",
+                m_entityID);
         }
 
         #endregion

--- a/src/EVEMon.Common/Properties/Resources.Designer.cs
+++ b/src/EVEMon.Common/Properties/Resources.Designer.cs
@@ -512,6 +512,15 @@ namespace EVEMon.Common.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error querying loyalty point balance of {0}..
+        /// </summary>
+        public static string ErrorLoyalty {
+            get {
+                return ResourceManager.GetString("ErrorLoyalty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error querying the market orders of {0}..
         /// </summary>
         public static string ErrorMarketOrders {

--- a/src/EVEMon.Common/Properties/Resources.resx
+++ b/src/EVEMon.Common/Properties/Resources.resx
@@ -396,4 +396,7 @@ If you changed your password, you must log in again using File &gt; Add Characte
   <data name="MessageNewContracts" xml:space="preserve">
     <value>{0} assigned contract{1}.</value>
   </data>
+  <data name="ErrorLoyalty" xml:space="preserve">
+    <value>Error querying loyalty point balance of {0}.</value>
+  </data>
 </root>

--- a/src/EVEMon.Common/QueryMonitor/CharacterDataQuerying.cs
+++ b/src/EVEMon.Common/QueryMonitor/CharacterDataQuerying.cs
@@ -174,6 +174,11 @@ namespace EVEMon.Common.QueryMonitor
                 OnPlanetaryColoniesUpdated, notifiers.
                 NotifyCharacterPlanetaryColoniesError) { QueryOnStartup = true });
             m_characterQueryMonitors.ForEach(monitor => ccpCharacter.QueryMonitors.Add(monitor));
+            // LP
+            m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPILoyality>(
+                ccpCharacter, ESIAPICharacterMethods.LoyaltyPoints,
+                OnLoyaltyPointsUpdated, notifiers.
+                NotifyCharacterLoyaltyPointsError) { QueryOnStartup = true });
 
             // Enumerate the basic feature monitors into a separate list
             m_basicFeaturesMonitors = new List<IQueryMonitorEx>(m_characterQueryMonitors.Count);
@@ -749,6 +754,23 @@ namespace EVEMon.Common.QueryMonitor
 
                 target.PlanetaryColonies.Import(result);
                 EveMonClient.OnCharacterPlanetaryColoniesUpdated(target);
+            }
+        }
+
+        /// <summary>
+        /// Processes the queried character's loyalty point information.
+        /// </summary>
+        /// <param name="result"></param>
+        private void OnLoyaltyPointsUpdated(EsiAPILoyality result)
+        {
+            var target = m_ccpCharacter;
+            // Character may have been deleted since we queried
+            if (target != null)
+            {
+                // Import the data
+                target.LoyaltyPoints.Import(result);
+                // Fires the event regarding standings update
+                EveMonClient.OnCharacterLoyaltyPointsUpdated(target);
             }
         }
 

--- a/src/EVEMon.Common/QueryMonitor/CharacterDataQuerying.cs
+++ b/src/EVEMon.Common/QueryMonitor/CharacterDataQuerying.cs
@@ -173,12 +173,12 @@ namespace EVEMon.Common.QueryMonitor
                 ccpCharacter, ESIAPICharacterMethods.PlanetaryColonies,
                 OnPlanetaryColoniesUpdated, notifiers.
                 NotifyCharacterPlanetaryColoniesError) { QueryOnStartup = true });
-            m_characterQueryMonitors.ForEach(monitor => ccpCharacter.QueryMonitors.Add(monitor));
             // LP
             m_characterQueryMonitors.Add(new CharacterQueryMonitor<EsiAPILoyality>(
                 ccpCharacter, ESIAPICharacterMethods.LoyaltyPoints,
                 OnLoyaltyPointsUpdated, notifiers.
                 NotifyCharacterLoyaltyPointsError) { QueryOnStartup = true });
+            m_characterQueryMonitors.ForEach(monitor => ccpCharacter.QueryMonitors.Add(monitor));
 
             // Enumerate the basic feature monitors into a separate list
             m_basicFeaturesMonitors = new List<IQueryMonitorEx>(m_characterQueryMonitors.Count);

--- a/src/EVEMon.Common/Serialization/Esi/EsiAPILoyalty.cs
+++ b/src/EVEMon.Common/Serialization/Esi/EsiAPILoyalty.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace EVEMon.Common.Serialization.Esi
+{
+    [CollectionDataContract]
+    public sealed class EsiAPILoyality : List<EsiLoyaltyListItem>
+    {
+    }
+}

--- a/src/EVEMon.Common/Serialization/Esi/EsiLoyaltyListItem.cs
+++ b/src/EVEMon.Common/Serialization/Esi/EsiLoyaltyListItem.cs
@@ -1,0 +1,14 @@
+﻿using System.Runtime.Serialization;
+
+namespace EVEMon.Common.Serialization.Esi
+{
+    [DataContract]
+    public sealed class EsiLoyaltyListItem
+    {
+        [DataMember(Name = "corporation_id")]
+        public int CorpID { get; set; }
+
+        [DataMember(Name = "loyalty_points")]
+        public int LoyaltyPoints { get; set; }
+    }
+}

--- a/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.Designer.cs
@@ -1,0 +1,78 @@
+﻿namespace EVEMon.CharacterMonitoring
+{
+    partial class CharacterLoyaltyList
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.noLoyaltyLabel = new System.Windows.Forms.Label();
+            this.lbLoyalty = new EVEMon.Common.Controls.NoFlickerListBox();
+            this.SuspendLayout();
+            // 
+            // noLoyaltyLabel
+            // 
+            this.noLoyaltyLabel.BackColor = System.Drawing.Color.WhiteSmoke;
+            this.noLoyaltyLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.noLoyaltyLabel.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.noLoyaltyLabel.Location = new System.Drawing.Point(0, 0);
+            this.noLoyaltyLabel.Name = "noLoyaltyLabel";
+            this.noLoyaltyLabel.Size = new System.Drawing.Size(328, 372);
+            this.noLoyaltyLabel.TabIndex = 2;
+            this.noLoyaltyLabel.Text = "Loyalty point information not available.";
+            this.noLoyaltyLabel.Click += new System.EventHandler(this.label1_Click);
+            // 
+            // lbLoyalty
+            // 
+            this.lbLoyalty.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.lbLoyalty.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lbLoyalty.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawVariable;
+            this.lbLoyalty.FormattingEnabled = true;
+            this.lbLoyalty.IntegralHeight = false;
+            this.lbLoyalty.ItemHeight = 15;
+            this.lbLoyalty.Location = new System.Drawing.Point(0, 0);
+            this.lbLoyalty.Margin = new System.Windows.Forms.Padding(0);
+            this.lbLoyalty.Name = "lbLoyalty";
+            this.lbLoyalty.Size = new System.Drawing.Size(328, 372);
+            this.lbLoyalty.TabIndex = 4;
+            // 
+            // CharacterLoyaltyList
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.noLoyaltyLabel);
+            this.Controls.Add(this.lbLoyalty);
+            this.Name = "CharacterLoyaltyList";
+            this.Size = new System.Drawing.Size(328, 372);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label noLoyaltyLabel;
+        private Common.Controls.NoFlickerListBox lbLoyalty;
+    }
+}

--- a/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.Designer.cs
@@ -42,6 +42,7 @@
             this.noLoyaltyLabel.Size = new System.Drawing.Size(328, 372);
             this.noLoyaltyLabel.TabIndex = 2;
             this.noLoyaltyLabel.Text = "Loyalty point information not available.";
+            this.noLoyaltyLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.noLoyaltyLabel.Click += new System.EventHandler(this.label1_Click);
             // 
             // lbLoyalty
@@ -57,6 +58,10 @@
             this.lbLoyalty.Name = "lbLoyalty";
             this.lbLoyalty.Size = new System.Drawing.Size(328, 372);
             this.lbLoyalty.TabIndex = 4;
+            this.lbLoyalty.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.lbLoyalty_DrawItem);
+            this.lbLoyalty.MeasureItem += new System.Windows.Forms.MeasureItemEventHandler(this.lbLoyalty_MeasureItem);
+            this.lbLoyalty.MouseDown += new System.Windows.Forms.MouseEventHandler(this.lbLoyalty_MouseDown);
+            this.lbLoyalty.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.lbLoyalty_MouseWheel);
             // 
             // CharacterLoyaltyList
             // 

--- a/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.Designer.cs
@@ -43,7 +43,6 @@
             this.noLoyaltyLabel.TabIndex = 2;
             this.noLoyaltyLabel.Text = "Loyalty point information not available.";
             this.noLoyaltyLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            this.noLoyaltyLabel.Click += new System.EventHandler(this.label1_Click);
             // 
             // lbLoyalty
             // 

--- a/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.cs
@@ -141,6 +141,7 @@ namespace EVEMon.CharacterMonitoring
 
                 foreach (Loyalty loyalty in loyaltyList)
                 {
+                    loyalty.LoyaltyCorpImageUpdated += loyalty_CorpImageUpdated;
                     lbLoyalty.Items.Add(loyalty);
                 }
 
@@ -223,24 +224,33 @@ namespace EVEMon.CharacterMonitoring
             // Draw texts
             TextRenderer.DrawText(g, corp, m_loyaltyBoldFont,
                                   new Rectangle(
-                                      e.Bounds.Left + PadLeft,
+                                      e.Bounds.Left + PadLeft * 7,
                                       e.Bounds.Top + PadTop,
                                       corpTextSize.Width + PadLeft,
                                       corpTextSize.Height), Color.Black);
 
             TextRenderer.DrawText(g, loyaltyText, m_loyaltyBoldFont,
                                   new Rectangle(
-                                      e.Bounds.Left + PadLeft,
+                                      e.Bounds.Left + PadLeft * 7,
                                       e.Bounds.Top + PadTop + corpTextSize.Height,
                                       loyaltyTextSize.Width + PadLeft,
                                       loyaltyTextSize.Height), Color.Black);
 
             TextRenderer.DrawText(g, pointText, m_loyaltyFont,
                                   new Rectangle(
-                                      e.Bounds.Left + PadLeft * 2 + loyaltyTextSize.Width,
+                                      e.Bounds.Left + PadLeft * (7 + 1) + loyaltyTextSize.Width,
                                       e.Bounds.Top + PadTop + corpTextSize.Height,
                                       pointTextSize.Width + PadLeft,
                                       pointTextSize.Height), Color.Black);
+
+            // Draw the corporation image
+            if (Settings.UI.SafeForWork)
+                return;
+
+            g.DrawImage(loyalty.CorporationImage,
+                        new Rectangle(e.Bounds.Left + PadLeft / 2,
+                                      LoyaltyDetailHeight / 2 - loyalty.CorporationImage.Height / 2 + e.Bounds.Top,
+                                      loyalty.CorporationImage.Width, loyalty.CorporationImage.Height));
         }
 
         /// <summary>
@@ -254,6 +264,17 @@ namespace EVEMon.CharacterMonitoring
 
 
         #region Local events
+
+        /// <summary>
+        /// When the image updates, we redraw the list.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="System.EventArgs"/> instance containing the event data.</param>
+        private void loyalty_CorpImageUpdated(object sender, EventArgs e)
+        {
+            // Force to redraw
+            lbLoyalty.Invalidate();
+        }
 
         /// <summary>
         /// Handles the MouseWheel event of the lbLoyalty control.

--- a/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.cs
@@ -1,0 +1,371 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using EVEMon.Common;
+using EVEMon.Common.Constants;
+using EVEMon.Common.Controls;
+using EVEMon.Common.CustomEventArgs;
+using EVEMon.Common.Enumerations;
+using EVEMon.Common.Extensions;
+using EVEMon.Common.Factories;
+using EVEMon.Common.Models;
+using EVEMon.Common.Properties;
+
+namespace EVEMon.CharacterMonitoring
+{
+    internal sealed partial class CharacterLoyaltyList : UserControl
+    {
+        #region Fields
+
+        private const TextFormatFlags Format = TextFormatFlags.NoPadding | TextFormatFlags.NoClipping | TextFormatFlags.NoPrefix;
+
+        // Standings drawing - Region & text padding
+        private const int PadTop = 2;
+        private const int PadLeft = 6;
+        private const int PadRight = 7;
+
+        // Loyalty drawing - Loyalty
+        private const int LoyaltyDetailHeight = 34;
+
+        private readonly Font m_loyaltyFont;
+        private readonly Font m_loyaltyBoldFont;
+
+        #endregion
+
+
+        #region Constructor
+
+        public CharacterLoyaltyList()
+        {
+            InitializeComponent();
+
+            lbLoyalty.Visible = false;
+
+            m_loyaltyFont = FontFactory.GetFont("Tahoma", 8.25F);
+            m_loyaltyBoldFont = FontFactory.GetFont("Tahoma", 8.25F, FontStyle.Bold);
+            noLoyaltyLabel.Font = FontFactory.GetFont("Tahoma", 11.25F, FontStyle.Bold);
+        }
+
+        #endregion
+
+
+        #region Properties
+
+        /// <summary>
+        /// Gets the character associated with this monitor.
+        /// </summary>
+        internal CCPCharacter Character { get; set; }
+
+        #endregion
+
+
+        #region Inherited events
+
+        /// <summary>
+        /// On load subscribe the events.
+        /// </summary>
+        /// <param name="e">An <see cref="T:System.EventArgs"/> that contains the event data.</param>
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+
+            if (DesignMode || this.IsDesignModeHosted())
+                return;
+
+            EveMonClient.CharacterLoyaltyPointsUpdated += EveMonClient_CharacterLoyaltyUpdated;
+            EveMonClient.SettingsChanged += EveMonClient_SettingsChanged;
+            EveMonClient.EveIDToNameUpdated += EveMonClient_EveIDToNameUpdated;
+            Disposed += OnDisposed;
+        }
+
+        /// <summary>
+        /// Unsubscribe events on disposing.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnDisposed(object sender, EventArgs e)
+        {
+            EveMonClient.CharacterLoyaltyPointsUpdated -= EveMonClient_CharacterLoyaltyUpdated;
+            EveMonClient.SettingsChanged -= EveMonClient_SettingsChanged;
+            EveMonClient.EveIDToNameUpdated -= EveMonClient_EveIDToNameUpdated;
+            Disposed -= OnDisposed;
+        }
+
+        /// <summary>
+        /// When the control becomes visible again, we update the content.
+        /// </summary>
+        /// <param name="e"></param>
+        protected override void OnVisibleChanged(EventArgs e)
+        {
+            base.OnVisibleChanged(e);
+
+            if (Visible)
+                UpdateContent();
+        }
+
+        #endregion
+
+
+        #region Content Management
+
+        /// <summary>
+        /// Updates the content.
+        /// </summary>
+        private void UpdateContent()
+        {
+            // Returns if not visible
+            if (!Visible)
+                return;
+
+            // When no character, we just hide the list
+            if (Character == null)
+            {
+                noLoyaltyLabel.Visible = true;
+                lbLoyalty.Visible = false;
+                return;
+            }
+
+            int scrollBarPosition = lbLoyalty.TopIndex;
+
+            // Update the standings list
+            lbLoyalty.BeginUpdate();
+            try
+            {
+                IEnumerable<Loyalty> loyaltyList = Character.LoyaltyPoints;
+
+                // Scroll through groups
+                lbLoyalty.Items.Clear();
+
+                foreach (Loyalty loyalty in loyaltyList)
+                {
+                    lbLoyalty.Items.Add(loyalty);
+                }
+
+                // Display or hide the "no standings" label.
+                noLoyaltyLabel.Visible = !loyaltyList.Any();
+                lbLoyalty.Visible = loyaltyList.Any();
+
+                // Invalidate display
+                lbLoyalty.Invalidate();
+            }
+            finally
+            {
+                lbLoyalty.EndUpdate();
+                lbLoyalty.TopIndex = scrollBarPosition;
+            }
+        }
+
+        #endregion
+
+
+        #region Drawing
+
+        /// <summary>
+        /// Handles the DrawItem event of the lbLoyalty control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="System.Windows.Forms.DrawItemEventArgs"/> instance containing the event data.</param>
+        private void lbLoyalty_DrawItem(object sender, DrawItemEventArgs e)
+        {
+            if (e.Index < 0 || e.Index >= lbLoyalty.Items.Count)
+                return;
+
+            Loyalty loyalty = lbLoyalty.Items[e.Index] as Loyalty;
+            DrawItem(loyalty, e);
+        }
+
+        /// <summary>
+        /// Handles the MeasureItem event of the lbLoyalty control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="System.Windows.Forms.MeasureItemEventArgs"/> instance containing the event data.</param>
+        private void lbLoyalty_MeasureItem(object sender, MeasureItemEventArgs e)
+        {
+            if (e.Index < 0)
+                return;
+            e.ItemHeight = GetItemHeight(lbLoyalty.Items[e.Index]);
+        }
+
+        /// <summary>
+        /// Gets the item's height.
+        /// </summary>
+        /// <param name="item"></param>
+        private int GetItemHeight(object item)
+        {
+            return Math.Max(m_loyaltyFont.Height * 2 + PadTop * 2, LoyaltyDetailHeight);
+        }
+
+        /// <summary>
+        /// Draws the list item for the given loyalty point balance
+        /// </summary>
+        /// <param name="loyalty"></param>
+        /// <param name="e"></param>
+        private void DrawItem(Loyalty loyalty, DrawItemEventArgs e)
+        {
+            Graphics g = e.Graphics;
+
+            // Draw background
+            g.FillRectangle(e.Index % 2 == 0 ? Brushes.White : Brushes.LightGray, e.Bounds);
+
+            // Texts
+            string loyaltyText = $"{loyalty.CorpId}  {loyalty.LoyaltyPoints}";
+
+            // Measure texts
+            Size loyaltyTextSize = TextRenderer.MeasureText(g, loyaltyText, m_loyaltyBoldFont, Size.Empty, Format);
+
+            // Draw texts
+            TextRenderer.DrawText(g, loyaltyText, m_loyaltyBoldFont,
+                                  new Rectangle(
+                                      e.Bounds.Left,
+                                      e.Bounds.Top,
+                                      loyaltyTextSize.Width + PadLeft,
+                                      loyaltyTextSize.Height), Color.Black);
+        }
+
+        /// <summary>
+        /// Gets the preferred size from the preferred size of the list.
+        /// </summary>
+        /// <param name="proposedSize"></param>
+        /// <returns></returns>
+        public override Size GetPreferredSize(Size proposedSize) => lbLoyalty.GetPreferredSize(proposedSize);
+
+        #endregion
+
+
+        #region Local events
+
+        /// <summary>
+        /// Handles the MouseWheel event of the lbLoyalty control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="System.Windows.Forms.MouseEventArgs"/> instance containing the event data.</param>
+        private void lbStandings_MouseWheel(object sender, MouseEventArgs e)
+        {
+            if (e.Delta == 0)
+                return;
+
+            // Update the drawing based upon the mouse wheel scrolling
+            int numberOfItemLinesToMove = e.Delta * SystemInformation.MouseWheelScrollLines / Math.Abs(e.Delta);
+            int lines = numberOfItemLinesToMove;
+            if (lines == 0)
+                return;
+
+            // Compute the number of lines to move
+            int direction = lines / Math.Abs(lines);
+            int[] numberOfPixelsToMove = new int[lines * direction];
+            for (int i = 1; i <= Math.Abs(lines); i++)
+            {
+                object item = null;
+
+                // Going up
+                if (direction == Math.Abs(direction))
+                {
+                    // Retrieve the next top item
+                    if (lbLoyalty.TopIndex - i >= 0)
+                        item = lbLoyalty.Items[lbLoyalty.TopIndex - i];
+                }
+                // Going down
+                else
+                {
+                    // Compute the height of the items from current the topindex (included)
+                    int height = 0;
+                    for (int j = lbLoyalty.TopIndex + i - 1; j < lbLoyalty.Items.Count; j++)
+                    {
+                        height += GetItemHeight(lbLoyalty.Items[j]);
+                    }
+
+                    // Retrieve the next bottom item
+                    if (height > lbLoyalty.ClientSize.Height)
+                        item = lbLoyalty.Items[lbLoyalty.TopIndex + i - 1];
+                }
+
+                // If found a new item as top or bottom
+                if (item != null)
+                    numberOfPixelsToMove[i - 1] = GetItemHeight(item) * direction;
+                else
+                    lines -= direction;
+            }
+
+            // Scroll 
+            if (lines != 0)
+                lbLoyalty.Invalidate();
+        }
+
+        /// <summary>
+        /// Handles the MouseDown event of the lbLoyalty control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="System.Windows.Forms.MouseEventArgs"/> instance containing the event data.</param>
+        private void lbStandings_MouseDown(object sender, MouseEventArgs e)
+        {
+            int index = lbLoyalty.IndexFromPoint(e.Location);
+            if (index < 0 || index >= lbLoyalty.Items.Count)
+                return;
+
+            Rectangle itemRect;
+
+            // Beware, this last index may actually means a click in the whitespace at the bottom
+            // Let's deal with this special case
+            if (index == lbLoyalty.Items.Count - 1)
+            {
+                itemRect = lbLoyalty.GetItemRectangle(index);
+                if (!itemRect.Contains(e.Location))
+                    return;
+            }
+        }
+
+        #endregion
+
+
+        #region Helper Methods
+
+        #endregion
+
+
+        #region Global events
+
+        /// <summary>
+        /// When the character loyalty point balances update, we refresh the content.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void EveMonClient_CharacterLoyaltyUpdated(object sender, CharacterChangedEventArgs e)
+        {
+            if (e.Character != Character)
+                return;
+
+            UpdateContent();
+        }
+
+        /// <summary>
+        /// When the settings change we update the content.
+        /// </summary>
+        /// <remarks>In case 'SafeForWork' gets enabled.</remarks>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="System.EventArgs"/> instance containing the event data.</param>
+        private void EveMonClient_SettingsChanged(object sender, EventArgs e)
+        {
+            UpdateContent();
+        }
+
+        /// <summary>
+        /// When the EVE ID to name changes we update the content.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="System.EventArgs"/> instance containing the event data.</param>
+        private void EveMonClient_EveIDToNameUpdated(object sender, EventArgs e)
+        {
+            UpdateContent();
+        }
+
+        #endregion
+
+        private void label1_Click(object sender, EventArgs e)
+        {
+
+        }
+    }
+}

--- a/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.cs
@@ -242,7 +242,7 @@ namespace EVEMon.CharacterMonitoring
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="System.Windows.Forms.MouseEventArgs"/> instance containing the event data.</param>
-        private void lbStandings_MouseWheel(object sender, MouseEventArgs e)
+        private void lbLoyalty_MouseWheel(object sender, MouseEventArgs e)
         {
             if (e.Delta == 0)
                 return;
@@ -299,7 +299,7 @@ namespace EVEMon.CharacterMonitoring
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="System.Windows.Forms.MouseEventArgs"/> instance containing the event data.</param>
-        private void lbStandings_MouseDown(object sender, MouseEventArgs e)
+        private void lbLoyalty_MouseDown(object sender, MouseEventArgs e)
         {
             int index = lbLoyalty.IndexFromPoint(e.Location);
             if (index < 0 || index >= lbLoyalty.Items.Count)

--- a/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.cs
@@ -401,10 +401,5 @@ namespace EVEMon.CharacterMonitoring
         }
 
         #endregion
-
-        private void label1_Click(object sender, EventArgs e)
-        {
-
-        }
     }
 }

--- a/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.cs
@@ -211,12 +211,14 @@ namespace EVEMon.CharacterMonitoring
             g.FillRectangle(e.Index % 2 == 0 ? Brushes.White : Brushes.LightGray, e.Bounds);
 
             // Texts - corp on first row, points on last row
-            string corp = $"{loyalty.CorpId}";
-            string loyaltyText = $"{loyalty.LoyaltyPoints} points";
+            string corp = loyalty.CorporationName;
+            string loyaltyText = $"{loyalty.LoyaltyPoints}";
+            string pointText = loyalty.LoyaltyPoints == 1 ? "point" : "points";
 
             // Measure texts
             Size corpTextSize = TextRenderer.MeasureText(g, corp, m_loyaltyBoldFont, Size.Empty, Format);
             Size loyaltyTextSize = TextRenderer.MeasureText(g, loyaltyText, m_loyaltyBoldFont, Size.Empty, Format);
+            Size pointTextSize = TextRenderer.MeasureText(g, pointText, m_loyaltyFont, Size.Empty, Format);
 
             // Draw texts
             TextRenderer.DrawText(g, corp, m_loyaltyBoldFont,
@@ -232,6 +234,13 @@ namespace EVEMon.CharacterMonitoring
                                       e.Bounds.Top + PadTop + corpTextSize.Height,
                                       loyaltyTextSize.Width + PadLeft,
                                       loyaltyTextSize.Height), Color.Black);
+
+            TextRenderer.DrawText(g, pointText, m_loyaltyFont,
+                                  new Rectangle(
+                                      e.Bounds.Left + PadLeft * 2 + loyaltyTextSize.Width,
+                                      e.Bounds.Top + PadTop + corpTextSize.Height,
+                                      pointTextSize.Width + PadLeft,
+                                      pointTextSize.Height), Color.Black);
         }
 
         /// <summary>

--- a/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.cs
@@ -210,17 +210,26 @@ namespace EVEMon.CharacterMonitoring
             // Draw background
             g.FillRectangle(e.Index % 2 == 0 ? Brushes.White : Brushes.LightGray, e.Bounds);
 
-            // Texts
-            string loyaltyText = $"{loyalty.CorpId}  {loyalty.LoyaltyPoints}";
+            // Texts - corp on first row, points on last row
+            string corp = $"{loyalty.CorpId}";
+            string loyaltyText = $"{loyalty.LoyaltyPoints} points";
 
             // Measure texts
+            Size corpTextSize = TextRenderer.MeasureText(g, corp, m_loyaltyBoldFont, Size.Empty, Format);
             Size loyaltyTextSize = TextRenderer.MeasureText(g, loyaltyText, m_loyaltyBoldFont, Size.Empty, Format);
 
             // Draw texts
+            TextRenderer.DrawText(g, corp, m_loyaltyBoldFont,
+                                  new Rectangle(
+                                      e.Bounds.Left + PadLeft,
+                                      e.Bounds.Top + PadTop,
+                                      corpTextSize.Width + PadLeft,
+                                      corpTextSize.Height), Color.Black);
+
             TextRenderer.DrawText(g, loyaltyText, m_loyaltyBoldFont,
                                   new Rectangle(
-                                      e.Bounds.Left,
-                                      e.Bounds.Top,
+                                      e.Bounds.Left + PadLeft,
+                                      e.Bounds.Top + PadTop + corpTextSize.Height,
                                       loyaltyTextSize.Width + PadLeft,
                                       loyaltyTextSize.Height), Color.Black);
         }

--- a/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.Designer.cs
@@ -685,6 +685,7 @@ namespace EVEMon.CharacterMonitoring
             this.loyaltyIcon.Tag = "loyaltyPage";
             this.loyaltyIcon.Text = "Loyalty Points";
             this.loyaltyIcon.ToolTipText = "Display loyalty point balances";
+            this.loyaltyIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // planetaryIcon
             // 

--- a/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.Designer.cs
@@ -78,6 +78,7 @@ namespace EVEMon.CharacterMonitoring
             this.walletJournalIcon = new System.Windows.Forms.ToolStripButton();
             this.walletTransactionsIcon = new System.Windows.Forms.ToolStripButton();
             this.jobsIcon = new System.Windows.Forms.ToolStripButton();
+            this.loyaltyIcon = new System.Windows.Forms.ToolStripButton();
             this.planetaryIcon = new System.Windows.Forms.ToolStripButton();
             this.researchIcon = new System.Windows.Forms.ToolStripButton();
             this.mailMessagesIcon = new System.Windows.Forms.ToolStripButton();
@@ -94,6 +95,8 @@ namespace EVEMon.CharacterMonitoring
             this.borderPanel = new EVEMon.Common.Controls.BorderPanel();
             this.corePanel = new System.Windows.Forms.Panel();
             this.multiPanel = new EVEMon.Common.Controls.MultiPanel.MultiPanel();
+            this.loyaltyPage = new EVEMon.Common.Controls.MultiPanel.MultiPanelPage();
+            this.loyaltyList = new EVEMon.CharacterMonitoring.CharacterLoyaltyList();
             this.standingsPage = new EVEMon.Common.Controls.MultiPanel.MultiPanelPage();
             this.standingsList = new EVEMon.CharacterMonitoring.CharacterStandingsList();
             this.skillsPage = new EVEMon.Common.Controls.MultiPanel.MultiPanelPage();
@@ -138,6 +141,7 @@ namespace EVEMon.CharacterMonitoring
             this.borderPanel.SuspendLayout();
             this.corePanel.SuspendLayout();
             this.multiPanel.SuspendLayout();
+            this.loyaltyPage.SuspendLayout();
             this.standingsPage.SuspendLayout();
             this.skillsPage.SuspendLayout();
             this.ordersPage.SuspendLayout();
@@ -485,6 +489,7 @@ namespace EVEMon.CharacterMonitoring
             this.walletJournalIcon,
             this.walletTransactionsIcon,
             this.jobsIcon,
+            this.loyaltyIcon,
             this.planetaryIcon,
             this.researchIcon,
             this.mailMessagesIcon,
@@ -670,6 +675,17 @@ namespace EVEMon.CharacterMonitoring
             this.jobsIcon.ToolTipText = "Display industry jobs";
             this.jobsIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
+            // loyaltyIcon
+            // 
+            this.loyaltyIcon.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.loyaltyIcon.Image = ((System.Drawing.Image)(resources.GetObject("loyaltyIcon.Image")));
+            this.loyaltyIcon.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.loyaltyIcon.Name = "loyaltyIcon";
+            this.loyaltyIcon.Size = new System.Drawing.Size(28, 28);
+            this.loyaltyIcon.Tag = "loyaltyPage";
+            this.loyaltyIcon.Text = "Loyalty Points";
+            this.loyaltyIcon.ToolTipText = "Display loyalty point balances";
+            // 
             // planetaryIcon
             // 
             this.planetaryIcon.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
@@ -828,6 +844,7 @@ namespace EVEMon.CharacterMonitoring
             // 
             // multiPanel
             // 
+            this.multiPanel.Controls.Add(this.loyaltyPage);
             this.multiPanel.Controls.Add(this.standingsPage);
             this.multiPanel.Controls.Add(this.skillsPage);
             this.multiPanel.Controls.Add(this.ordersPage);
@@ -852,6 +869,25 @@ namespace EVEMon.CharacterMonitoring
             this.multiPanel.SelectedPage = this.skillsPage;
             this.multiPanel.Size = new System.Drawing.Size(608, 181);
             this.multiPanel.TabIndex = 14;
+            // 
+            // loyaltyPage
+            // 
+            this.loyaltyPage.Controls.Add(this.loyaltyList);
+            this.loyaltyPage.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.loyaltyPage.Location = new System.Drawing.Point(0, 0);
+            this.loyaltyPage.Name = "loyaltyPage";
+            this.loyaltyPage.Size = new System.Drawing.Size(608, 181);
+            this.loyaltyPage.TabIndex = 18;
+            this.loyaltyPage.Tag = "LoyaltyPoints";
+            this.loyaltyPage.Text = "loyaltyPage";
+            // 
+            // loyaltyList
+            // 
+            this.loyaltyList.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.loyaltyList.Location = new System.Drawing.Point(0, 0);
+            this.loyaltyList.Name = "loyaltyList";
+            this.loyaltyList.Size = new System.Drawing.Size(608, 181);
+            this.loyaltyList.TabIndex = 0;
             // 
             // standingsPage
             // 
@@ -1259,6 +1295,7 @@ namespace EVEMon.CharacterMonitoring
             this.borderPanel.ResumeLayout(false);
             this.corePanel.ResumeLayout(false);
             this.multiPanel.ResumeLayout(false);
+            this.loyaltyPage.ResumeLayout(false);
             this.standingsPage.ResumeLayout(false);
             this.skillsPage.ResumeLayout(false);
             this.ordersPage.ResumeLayout(false);
@@ -1384,5 +1421,8 @@ namespace EVEMon.CharacterMonitoring
         private CharacterPlanetaryList planetaryList;
         private System.Windows.Forms.ToolStripSeparator tsPlanetarySeparator;
         private System.Windows.Forms.ToolStripMenuItem showOnlyExtractorMenuItem;
+        private System.Windows.Forms.ToolStripButton loyaltyIcon;
+        private Common.Controls.MultiPanel.MultiPanelPage loyaltyPage;
+        private CharacterLoyaltyList loyaltyList;
     }
 }

--- a/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.cs
@@ -377,6 +377,9 @@ namespace EVEMon.CharacterMonitoring
             // Enables / Disables the EVE notifications page related controls
             if (multiPanel.SelectedPage == eveNotificationsPage)
                 toolStripContextual.Enabled = ccpCharacter.EVENotifications.Any();
+
+            if (multiPanel.SelectedPage == loyaltyPage)
+                toolStripContextual.Enabled = ccpCharacter.LoyaltyPoints.Any();
         }
 
         /// <summary>
@@ -1619,6 +1622,7 @@ namespace EVEMon.CharacterMonitoring
             walletTransactionsList.Character = ccpCharacter;
             jobsList.Character = ccpCharacter;
             planetaryList.Character = ccpCharacter;
+            loyaltyList.Character = ccpCharacter;
             researchList.Character = ccpCharacter;
             mailMessagesList.Character = ccpCharacter;
             eveNotificationsList.Character = ccpCharacter;
@@ -1629,7 +1633,7 @@ namespace EVEMon.CharacterMonitoring
             {
                 standingsIcon, contactsIcon, factionalWarfareStatsIcon, medalsIcon,
                 killLogIcon, assetsIcon, ordersIcon, contractsIcon, walletJournalIcon,
-                walletTransactionsIcon, jobsIcon, planetaryIcon, researchIcon, mailMessagesIcon,
+                walletTransactionsIcon, jobsIcon, planetaryIcon, loyaltyIcon, researchIcon, mailMessagesIcon,
                 eveNotificationsIcon, calendarEventsIcon
             });
 

--- a/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.cs
@@ -377,9 +377,6 @@ namespace EVEMon.CharacterMonitoring
             // Enables / Disables the EVE notifications page related controls
             if (multiPanel.SelectedPage == eveNotificationsPage)
                 toolStripContextual.Enabled = ccpCharacter.EVENotifications.Any();
-
-            if (multiPanel.SelectedPage == loyaltyPage)
-                toolStripContextual.Enabled = ccpCharacter.LoyaltyPoints.Any();
         }
 
         /// <summary>
@@ -552,6 +549,7 @@ namespace EVEMon.CharacterMonitoring
             toolStripContextual.Visible = m_advancedFeatures.Any(button => (string)button.Tag != standingsPage.Text &&
                                                                            (string)button.Tag != factionalWarfareStatsPage.Text &&
                                                                            (string)button.Tag != medalsPage.Text &&
+                                                                           (string)button.Tag != loyaltyPage.Text &&
                                                                            (string)button.Tag == e.NewPage.Text);
 
             // Reset the text filter

--- a/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.resx
@@ -800,6 +800,50 @@
         qhGZsQlp06K0WL8P7PNfiQ+0/sEGgvS3B74b6H/ClJT+AYCcYWhNsprsAAAAAElFTkSuQmCC
 </value>
   </data>
+  <data name="loyaltyIcon.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAjBSURBVHhe7Zp7UJNXFsBTCE8JhJcQ5CEIxDAoj1SkNKvo
+        UkXZKYLyCGqEoMi7LqwsFhCKUSKmShGQd3lJETEr0cCKEIFBhqJ1s8Iyi1PoWrvMDtthZ9KZ+Ef+OHtv
+        CDNtx6p5yDO/mTO5ud/znnO/c+4530fQokWLFi1LB9HV1dVa0V57RB2MCszKyuo2MDBwUXStDbDVg4KC
+        GAN9A/zLxZel7u7uyVQq1Q5tIs3vsco5dvRYTu+9Xsn3099Db08vdN/tlsUei50kkUh/QJsN5/da3Vgn
+        nkhsHf/7OFwsugh0X7oM9dUh8UBCxDuseqoqqriHYw7LTExM5pjRTKmenh4bda846xMdHR3NFW1lIPr5
+        +XHRoEtQO8LKwqqcSCRmorayCiB6e3vjKLIks4Z45MiR7dmnswWorYoXxzeOHR++eez8HBXtt4UYFRUV
+        WJBXcH/Rowj24qEhoYEDogF+MbdY6ursuqheXB5FdgYxRH0iAaeQI3V2dl7cKBIXF7ekXhxHkZ6/9kie
+        Tz1fsiiy1F7cmsVi1Y2Jx5YuitRU1pQgS6jlxS0tLfGUVemGqyurOUsZRYj+/v5qe/Erl/LTGQxGMGoq
+        qwQi3YdeoKury0NtdaKIWqjtxRvKzw2dz8/gm5tT8LHKgsOvOtdfWqhUS7u/NHJl92/Xzfn7bwtTdK8d
+        9vk5sESNsTA9XAvso5FVqGtxQthy4bPk37VjBYwIy6D6SrbYzs7OXbFpTUCsztw+91SQCT0N6dB7I1+y
+        Y8cOFu6f37zK8fLyCmwr3A3/7MmBvpZMGO7kQEpSSpOKecXK40joLk5fdThMP7wCTwRnYKDlBNTVlI/T
+        6XSGYpfVTXF+hvjr9iSkgMvw48QNEFaEg/DODUnkoUOZW7dudccZHtWSip3iosZ1taBSHewOhu4NjIsO
+        CUs9fpCZ+8khVkbCxxEZ8bsjspODmNnxjAgsf2TRWX314TAhSIEZcS28fNEHj2/EgVhUCcL2q+I7na2C
+        682VTbeuVzfdaqutamv8ouTLa5cKbl8v5d7jV3Eby3K4SXHhQeiSi+ov3li9Pc46FHYu99Rs783PAcut
+        6sx5qWAjiUdWjpELHjyWb/vy5AqQfHsHfvi6DB7yP4XJUT6MDTXL5Ul/CwyjCPFAUAGjojYY7mmBm02l
+        cOJo6JSZmXkCuuTrwqaqdYpXQsTV29MZp9+U92OLBFKsjEcO7KZBGeckTPRXwt96uPCg4yx01bOgr/Uk
+        PO6Ih7GuTJge5MCP/7gOL//7BH5AinjWz4GJnlwY6cwC8b2zMCjIgYlhHnS15EJRViREhtBlFFtzMcr9
+        8eBfZwzigQMH6Hl5eepXm318fOxCQkKCcN5ddL5I6uTk9Ka8GyvBUU+XwHPcYCpxtidDXFQglBSy4JHw
+        DMw8rYX/jLfIZfZpA/w0dRd++vegXAHybRMN8N0oD+41nITSgnBIjfKB6H2+sJliIiW8R+Cjcwci+U2/
+        gK0eHBzMGBANCCquVkg9PDwyXVxc8BJZtUWWGnk/viBe3o4bGxqAtbkpONpZwq4PtwLv7DHo67gAs8j5
+        vXwhRI9BFYzfL4T+pkPQ/BkD8k94QWoEFcJ3OUOA53qgWKybQucpQIKt+drnPpYV+2dRj0hzdQojIyM7
+        NfJ+vN1FV/e9ckN9PSnZxBCw0DaSIcDbAWovHYep0Xp4dDtLroCaT/2Al0SDU0waRH/kBL5US5mpsc4Q
+        OgdeIL3W//wM65TElNaJsQnN1Qk0kPfj2RBhoEMY9/fcALysj0HcWwL/+04IHVcTkTIcYfpRA/zrKQqH
+        18IhJ/H34OezUUrQJTSh4/C6QKkb10Sd4udoJO9HEHe878zuqmTD9GitXEbuXoScoz7yGZHCCoKZZ0IY
+        aEuBpgvRcP5U8HOUG6gS6jR1v79A3bxfDu9MVPlwey487q2EFxOdkML0hZh9bmC3ngTrLdYB53QM9PMv
+        QMXZaGguTZfRaDRsOVWmrUbuV+PUc+NmHrbnyAf/Re5h2O9vC/s/oIAV2VjhG2zlCmjgnYS6IjaEhYXh
+        Z1c1773c8PBwZwjr/wQTohooKWCjwVLAj2YDW1ytwHSdnszEmAgUsiF85O8KnV9mQdm5WCjMTZ+kUCh0
+        xSlWNqWXizgP+VwYRhLg7SZXgL2NqczYWH+IoEPI0dfXGbFFCsBKSGLuhM76LGisOi/bvHlzMjp86aev
+        upzLS5160sWDwAAaWFiYgJGRgQR1Yy+/sLBBiyddnomRvpSMlMDJiABhKw8iw/fwkTd/2xC4PPHdvIl+
+        +2YZfBK/H/Dg9PSIM6ibg+TXCxuSDoHAJJH0ppzsLaC5ogDO5yQ/R2uR7YrtK5PP8+IL6i+lg6mJsUxH
+        R0eMurB3/y2rYoV4IeH7erpB27VsmSKOr9zHoCCTKTYjG+Mpj5MpHNvfJiZb4/gduueD2YCAgFb0f/lG
+        A0Xa+UoLmZubO9I2OeAkBk95bFllLIkVFeThvnHhcfk1Gk15VQLXCIq5xe0o42Kiv6+yLB4wrvaq6sjw
+        8dj6v1AcykoN8avxtNS0dvRXlZcq6oFvYMuWLS5paWnsMfGYZO/evUM2NjbbbW1t8UCVsbLSYKvLP7BC
+        KS/+wAq/GndwcHhdiq55GAyGS1V5lfib0W9k08+mQdQrgvy8fMm2bdvwC453ahGUoid0C7slszOzMNg/
+        CG2tbbIYZswkmURe1A+siPb29sFfNX0119HWAdlZ2YD6JpHg1PVdP5fmCQkJTcODw8Ap5ACdvkQfWDHe
+        Z7g0NzTPkclkyZ49e6SeNM8HqFu9EtRbgqxewo5jy0gkkjzlRV1qpbwqsfPDnQy3TW5Y8zjdZNtvsMcO
+        CVvhXSNPedHvfMprZVVuZmamdsqrCni6YYsveGnsiJSd/qqGsuWZ8ioJMSYyJkgj1duVBl4/LFSbF6q3
+        bm5uC7Np9YOrzYJbgrX9rbDGq7crDU1Xb1ca76R6u9JYFaFMixYtWrRoWbEQCP8H4hUuaBGa/7sAAAAA
+        SUVORK5CYII=
+</value>
+  </data>
   <data name="planetaryIcon.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8

--- a/src/EVEMon/Controls/KillReportAttacker.cs
+++ b/src/EVEMon/Controls/KillReportAttacker.cs
@@ -7,6 +7,7 @@ using EVEMon.Common.Constants;
 using EVEMon.Common.Controls;
 using EVEMon.Common.Data;
 using EVEMon.Common.Enumerations;
+using EVEMon.Common.Helpers;
 using EVEMon.Common.Models;
 using EVEMon.Common.Serialization.Eve;
 using EVEMon.Common.Service;
@@ -116,28 +117,16 @@ namespace EVEMon.Controls
         /// <returns></returns>
         private Uri GetImageUrl(PictureBox pictureBox, bool useFallbackUri)
         {
-            string path;
-
             if (pictureBox == CharacterPictureBox)
             {
-                path = string.Format(CultureConstants.InvariantCulture,
-                    NetworkConstants.CCPPortraits, m_attacker.ID, (int)EveImageSize.x64);
-
-                return useFallbackUri
-                    ? ImageService.GetImageServerBaseUri(path)
-                    : ImageService.GetImageServerCdnUri(path);
+                return ImageHelper.GetPortraitUrl(useFallbackUri, m_attacker.ID, (int)EveImageSize.x64);
             }
 
             int typeId = pictureBox.Equals(ShipPictureBox)
                 ? m_attacker.ShipTypeID
                 : m_attacker.WeaponTypeID;
 
-            path = string.Format(CultureConstants.InvariantCulture,
-                NetworkConstants.CCPIconsFromImageServer, "type", typeId, (int)EveImageSize.x32);
-
-            return useFallbackUri
-                ? ImageService.GetImageServerBaseUri(path)
-                : ImageService.GetImageServerCdnUri(path);
+            return ImageHelper.GetImageUrl(useFallbackUri, "type", typeId);
         }
 
         #endregion

--- a/src/EVEMon/Controls/KillReportVictim.cs
+++ b/src/EVEMon/Controls/KillReportVictim.cs
@@ -121,30 +121,19 @@ namespace EVEMon.Controls
         /// <returns></returns>
         private Uri GetImageUrl(PictureBox pictureBox, bool useFallbackUri)
         {
-            string path = string.Empty;
-
             if (pictureBox.Equals(CharacterPictureBox))
-                path = string.Format(CultureConstants.InvariantCulture,
-                    NetworkConstants.CCPPortraits, m_killLog.Victim.ID, (int)EveImageSize.x128);
+                return ImageHelper.GetPortraitUrl(useFallbackUri, m_killLog.Victim.ID,
+                    (int)EveImageSize.x128);
 
             if (pictureBox.Equals(ShipPictureBox))
-                path = string.Format(CultureConstants.InvariantCulture,
-                    NetworkConstants.CCPIconsFromImageServer, "render", m_killLog.Victim.ShipTypeID,
+                return ImageHelper.GetImageUrl(useFallbackUri, "render", m_killLog.Victim.ShipTypeID,
                     (int)EveImageSize.x128);
 
             if (pictureBox.Equals(CorpPictureBox))
-                path = string.Format(CultureConstants.InvariantCulture,
-                    NetworkConstants.CCPIconsFromImageServer, "corporation", m_killLog.Victim.CorporationID,
-                    (int)EveImageSize.x32);
+                return ImageHelper.GetImageUrl(useFallbackUri, "corporation", m_killLog.Victim.CorporationID);
 
-            if (pictureBox.Equals(AlliancePictureBox))
-                path = string.Format(CultureConstants.InvariantCulture,
-                    NetworkConstants.CCPIconsFromImageServer, "alliance", m_killLog.Victim.AllianceID,
-                    (int)EveImageSize.x32);
-
-            return useFallbackUri
-                ? ImageService.GetImageServerBaseUri(path)
-                : ImageService.GetImageServerCdnUri(path);
+            // Picture box is for alliance
+            return ImageHelper.GetImageUrl(useFallbackUri, "alliance", m_killLog.Victim.AllianceID);
         }
 
         #endregion

--- a/src/EVEMon/EVEMon.csproj
+++ b/src/EVEMon/EVEMon.csproj
@@ -161,6 +161,12 @@
     <Compile Include="CharacterMonitoring\CharacterKillLogList.Designer.cs">
       <DependentUpon>CharacterKillLogList.cs</DependentUpon>
     </Compile>
+    <Compile Include="CharacterMonitoring\CharacterLoyaltyList.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="CharacterMonitoring\CharacterLoyaltyList.Designer.cs">
+      <DependentUpon>CharacterLoyaltyList.cs</DependentUpon>
+    </Compile>
     <Compile Include="CharacterMonitoring\CharacterMedalsList.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -551,6 +557,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="CharacterMonitoring\CharacterKillLogList.resx">
       <DependentUpon>CharacterKillLogList.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="CharacterMonitoring\CharacterLoyaltyList.resx">
+      <DependentUpon>CharacterLoyaltyList.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="CharacterMonitoring\CharacterMedalsList.resx">
       <DependentUpon>CharacterMedalsList.cs</DependentUpon>


### PR DESCRIPTION
This pull request adds a loyalty point list as an option in the advanced features drop down menu. This allows one to view the loyalty point balances of each corporation the character has complete missions or did factional warfare for. It uses the ESI endpoint for a character's loyalty point balance.

- For each list item, the corporation name, logo, and point balance is displayed.
- At the moment the default Alliance logo is used for the button image, but it could be changed to better fit the feature.
- Due to the resemblance of the employment/standings list, I didn't implement the ability to sort by corp name or point amount. I think it can be done but would probably require making the list look more like the assets or wallet journal so I'm not sure if I want to proceed that route without your input on that. This also means the contextual tool strip is disabled for the Loyalty Point list.
- ~~The image functionality was duplicated from that for the Employment History list, perhaps it should be refactored into another class?~~