### PR TITLE
Fix planetary pins to alert on timer function

### DIFF
--- a/src/EVEMon.Common/Models/Collections/PlanetaryColonyCollection.cs
+++ b/src/EVEMon.Common/Models/Collections/PlanetaryColonyCollection.cs
@@ -90,8 +90,10 @@ namespace EVEMon.Common.Models.Collections
                 return;
 
             // Add the not notified idle pins to the completed list
+            // Updated 3/10/2019, removed check on Pin state = Idle, as the state doesn't get updated unless the planetary column is visible
+            // Left in the check on PinState not equal to none as that prevents alerts popping for non-activatable items (storages, etc.)
             List<PlanetaryPin> pinsCompleted = Items.SelectMany(x => x.Pins).Where(
-                pin => pin.State == PlanetaryPinState.Idle && pin.TTC.Length == 0 && !pin.NotificationSend).ToList();
+                pin => pin.State != PlanetaryPinState.None && pin.TTC.Length == 0 && !pin.NotificationSend).ToList();
 
             pinsCompleted.ForEach(pin => pin.NotificationSend = true);
 


### PR DESCRIPTION
This commit addresses #153 

The issue is that the previous timer tick only fired a notification when the Pin state was set to Idle, but that change can only happen when the PI view is selected in the application.  This change removes that filter so that the notifications will fire appropriately.  The inclusion of the filter on not "None" is still needed to prevent the alert from firing for non-extractor modules.