### PR TITLE
Updates to fix changed value for reactions (for tracking reaction jobs)

### DIFF
--- a/src/EVEMon.Common/Enumerations/BlueprintActivity.cs
+++ b/src/EVEMon.Common/Enumerations/BlueprintActivity.cs
@@ -34,6 +34,9 @@ namespace EVEMon.Common.Enumerations
         [Description("Invention")]
         Invention = 8,
 
+        [Description("Simple Reactions")]
+        SimpleReactions = 9,
+
         [Description("Reactions")]
         Reactions = 11
     }

--- a/src/EVEMon.Common/Models/IndustryJob.cs
+++ b/src/EVEMon.Common/Models/IndustryJob.cs
@@ -13,7 +13,7 @@ namespace EVEMon.Common.Models
     public sealed class IndustryJob
     {
         #region Static Helpers
-        
+
         /// <summary>
         /// Gets the maximum number of active manufacturing jobs allowed by a character's
         /// skills.
@@ -388,6 +388,7 @@ namespace EVEMon.Common.Models
                 case BlueprintActivity.Invention:
                 case BlueprintActivity.ReverseEngineering:
                     return StaticBlueprints.GetBlueprintByID(id) ?? StaticItems.GetItemByID(0);
+                case BlueprintActivity.SimpleReactions:
                 case BlueprintActivity.Reactions:
                     return StaticItems.GetItemByID(InstalledItem?.ReactionOutcome?.Item?.ID ?? 0);
                 default:

--- a/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.cs
@@ -753,6 +753,8 @@ namespace EVEMon.CharacterMonitoring
                 case BlueprintActivity.Manufacturing:
                     // Returns the amount produced
                     return (long)job.Runs * job.OutputItem.PortionSize;
+                case BlueprintActivity.SimpleReactions:
+                    return job.Runs * job.InstalledItem.ReactionOutcome.Quantity;
                 case BlueprintActivity.Reactions:
                     return job.Runs * job.InstalledItem.ReactionOutcome.Quantity;
                 default:
@@ -1169,7 +1171,7 @@ namespace EVEMon.CharacterMonitoring
             UpdateColumns();
         }
 
-#endregion
+        #endregion
 
 
         #region Updates Expandable Panel On Global Events
@@ -1234,7 +1236,7 @@ namespace EVEMon.CharacterMonitoring
             // Basic label text
             m_lblActiveManufacturingJobs.Text = "Active Manufacturing Jobs: " +
                 m_activeManufacturing.Total;
-            m_lblActiveResearchingJobs.Text = "Active Researching Jobs: " + 
+            m_lblActiveResearchingJobs.Text = "Active Researching Jobs: " +
                 m_activeResearch.Total;
             m_lblActiveReactionJobs.Text = "Active Reaction Jobs: " + m_activeReactions.Total;
             m_lblRemoteManufacturingRange.Text = "Remote Manufacturing Range: limited to " +
@@ -1327,8 +1329,8 @@ namespace EVEMon.CharacterMonitoring
                 BlueprintActivity.ResearchingMaterialEfficiency, BlueprintActivity.Copying,
                 BlueprintActivity.Duplicating, BlueprintActivity.Invention, BlueprintActivity.
                 ReverseEngineering, BlueprintActivity.ResearchingTimeEfficiency);
-            m_activeReactions = new JobsIssued(m_list, BlueprintActivity.Reactions);
-            
+            m_activeReactions = new JobsIssued(m_list, BlueprintActivity.SimpleReactions, BlueprintActivity.Reactions);
+
             // Calculate character's max manufacturing jobs
             m_skillBasedManufacturingJobs = IndustryJob.MaxManufacturingJobsFor(Character);
             // Calculate character's max researching jobs

--- a/src/EVEMon/SkillPlanner/BlueprintBrowserControl.cs
+++ b/src/EVEMon/SkillPlanner/BlueprintBrowserControl.cs
@@ -256,6 +256,9 @@ namespace EVEMon.SkillPlanner
                     case BlueprintActivity.Invention:
                         invention = true;
                         break;
+                    case BlueprintActivity.SimpleReactions:
+                        reactions = true;
+                        break;
                     case BlueprintActivity.Reactions:
                         reactions = true;
                         break;
@@ -280,6 +283,9 @@ namespace EVEMon.SkillPlanner
                         break;
                     case BlueprintActivity.Invention:
                         invention = true;
+                        break;
+                    case BlueprintActivity.SimpleReactions:
+                        reactions = true;
                         break;
                     case BlueprintActivity.Reactions:
                         reactions = true;
@@ -884,6 +890,10 @@ namespace EVEMon.SkillPlanner
                     PropertiesList = lvReactions;
                     activity = BlueprintActivity.Reactions;
                     break;
+                case "Simple Reactions":
+                    PropertiesList = lvReactions;
+                    activity = BlueprintActivity.SimpleReactions;
+                    break;
                 default:
                     throw new NotImplementedException();
             }
@@ -1001,7 +1011,7 @@ namespace EVEMon.SkillPlanner
             return multiplier;
         }
 
-#endregion
+        #endregion
 
 
         #region Event Handlers
@@ -1099,7 +1109,7 @@ namespace EVEMon.SkillPlanner
             // Data Browser
             else
                 settings = Settings.UI.BlueprintDataBrowser;
-            
+
             settings.ImplantSetIndex = cbImplantSet.SelectedIndex;
             cbImplantSet.Tag = cbImplantSet.SelectedItem;
 


### PR DESCRIPTION
Since early July, it appears that the value returned by ESI for reaction jobs has changed, causing the reaction job counter to be incorrect in the UI.  I've added a new enumeration to the group and called it SimpleReaction, it's not clear why the change was made (I've not found any documentation on it and initially guessed it to be in error), but the SDE appears to still have the old value as well still last I checked.  In any case, this corrects the UI.  I suppose if we think this is a long term change we can change the original value, but this change makes it work either way.