### PR TITLE
Move to characters v5 endpoint

### DIFF
--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      Revision
 //
 [assembly: AssemblyVersion("4.0.20.0")]
-[assembly: AssemblyFileVersion("4.0.20.4986")]
+[assembly: AssemblyFileVersion("4.0.20.4987")]
 [assembly: AssemblyInformationalVersion("4.0.20")]
 
 // Neutral Language

--- a/src/EVEMon.Common/Constants/NetworkConstants.resx
+++ b/src/EVEMon.Common/Constants/NetworkConstants.resx
@@ -182,7 +182,7 @@
     <comment>600</comment>
   </data>
   <data name="ESICharacterSheet" xml:space="preserve">
-    <value>/v4/characters/{0:D}/</value>
+    <value>/v5/characters/{0:D}/</value>
     <comment>3600</comment>
   </data>
   <data name="ESIStandings" xml:space="preserve">

--- a/src/EVEMon.Common/Constants/NetworkConstants1.Designer.cs
+++ b/src/EVEMon.Common/Constants/NetworkConstants1.Designer.cs
@@ -268,7 +268,7 @@ namespace EVEMon.Common.Constants {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to /v4/characters/{0:D}/.
+        ///   Looks up a localized string similar to /v5/characters/{0:D}/.
         /// </summary>
         public static string ESICharacterSheet {
             get {


### PR DESCRIPTION
Update NetworkConstants for the new v5 ESICharacterSheet endpoint. The old v4 endpoint has been deprecated and removed by CCP. 

Fixes #300  