### PR TITLE
Support CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,25 @@
+version: 2.1
+
+orbs:
+  windows: circleci/windows@2.2.0
+
+jobs:
+  build:
+    description: Build application with Release configuration
+    executor:
+      name: windows/default
+    steps:
+      - checkout
+      - run:
+          name: "NuGet"
+          command: nuget.exe restore EVEMon.sln
+      - run:
+          name: "Build Application according to some given configuration"
+          command: msbuild -t:build -restore -p:BclBuildImported=Ignore  -p:Configuration=Release EVEMon.sln 
+      - store_artifacts:
+          path: src\EVEMon\bin\Installbuilder\Installer\
+          destination: Installer
+workflows:
+  test_and_build:
+    jobs:
+      - build


### PR DESCRIPTION
It can be difficult to trust that the artifact stored on a Git release is the
artifact built by that commit. EVE being as hard-core as it is, the risk of a
trojan is above nil.  By building the application in a visible CI tool we can
be more confident the result is based on the code.

Further, this allows someone to fork the repo and create a build of their own
(using CircleCI) without locally installing development tools.